### PR TITLE
Added WFS layer which returns only Rottnest Shelf files.

### DIFF
--- a/gwc-layers/LayerInfoImpl--50868d64_1439e738332_21e3.xml
+++ b/gwc-layers/LayerInfoImpl--50868d64_1439e738332_21e3.xml
@@ -1,7 +1,7 @@
 <GeoServerTileLayer>
   <id>LayerInfoImpl--50868d64:1439e738332:21e3</id>
   <enabled>true</enabled>
-  <name>imos:acorn_hourly_avg_qc_timeseries_url_rot</name>
+  <name>imos:acorn_hourly_avg_rot_qc_timeseries_url</name>
   <mimeFormats>
     <string>image/png</string>
     <string>image/jpeg</string>

--- a/workspaces/imos/JNDI_dbprod_harvest_acorn_hourly_avg_qc/acorn_hourly_avg_rot_qc_timeseries_url/featuretype.xml
+++ b/workspaces/imos/JNDI_dbprod_harvest_acorn_hourly_avg_qc/acorn_hourly_avg_rot_qc_timeseries_url/featuretype.xml
@@ -1,11 +1,11 @@
 <featureType>
   <id>FeatureTypeInfoImpl--50868d64:1439e738332:21e2</id>
-  <name>acorn_hourly_avg_qc_timeseries_url_rot</name>
+  <name>acorn_hourly_avg_rot_qc_timeseries_url</name>
   <nativeName>acorn_hourly_avg_qc_timeseries_url_rot</nativeName>
   <namespace>
     <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
   </namespace>
-  <title>acorn_hourly_avg_qc_timeseries_url_rot</title>
+  <title>acorn_hourly_avg_rot_qc_timeseries_url</title>
   <keywords>
     <string>acorn_url</string>
     <string>features</string>
@@ -36,7 +36,7 @@
     <entry key="JDBC_VIRTUAL_TABLE">
       <virtualTable>
         <name>acorn_hourly_avg_qc_timeseries_url_rot</name>
-        <sql>select *, ST_makepoint(1, 2) from acorn_hourly_avg_qc.acorn_hourly_avg_qc_timeseries_url where site_code = 'ROT, Rottnest Shelf'</sql>
+        <sql>select *, ST_makepoint(1, 2) from acorn_hourly_avg_qc.acorn_hourly_avg_qc_timeseries_url where site_code = &apos;ROT, Rottnest Shelf&apos;</sql>
         <escapeSql>false</escapeSql>
         <geometry>
           <name>st_makepoint</name>

--- a/workspaces/imos/JNDI_dbprod_harvest_acorn_hourly_avg_qc/acorn_hourly_avg_rot_qc_timeseries_url/layer.xml
+++ b/workspaces/imos/JNDI_dbprod_harvest_acorn_hourly_avg_qc/acorn_hourly_avg_rot_qc_timeseries_url/layer.xml
@@ -1,5 +1,5 @@
 <layer>
-  <name>acorn_hourly_avg_qc_timeseries_url_rot</name>
+  <name>acorn_hourly_avg_rot_qc_timeseries_url</name>
   <id>LayerInfoImpl--50868d64:1439e738332:21e3</id>
   <type>VECTOR</type>
   <defaultStyle>


### PR DESCRIPTION
This is to give a 1:1 correspondence between geonetwork records (i.e. 123 search results) and geoserver layers.

Required for BODAAC.

The way we've got it setup, there needs to be one layer per ACORN site (so that the portal doesn't have to do any CQL filtering) - so some other layers will need to be set up for ACORN.

@ggalibert come talk to me about this if you like.
