### PR TITLE
ABOS SOTS new layer

### DIFF
--- a/workspaces/imos/JNDI_abos_sots/abos_sots_map/content.ftl
+++ b/workspaces/imos/JNDI_abos_sots/abos_sots_map/content.ftl
@@ -1,0 +1,19 @@
+<#import "config.ftl" as my>
+
+<h3>ABOS Southern Ocean Time Series Moorings</h3>
+
+<#list features as feature>
+<div class="feature">
+
+<h4>${feature.site_code.value} - ${feature.platform_code.value} </h4>
+<b>LON/LAT</b> ${feature.LONGITUDE.value}/${feature.LATITUDE.value}<br/>
+<b>Product :</b>${feature.data_type.value}</h4><br/>
+<b>deployment start :</b>${feature.time_coverage_start.value}<br/>
+<b>deployement end  :</b>${feature.time_coverage_end.value}<br/>
+
+
+<BR>
+
+</div>
+
+</#list>

--- a/workspaces/imos/JNDI_abos_sots/abos_sots_map/featuretype.xml
+++ b/workspaces/imos/JNDI_abos_sots/abos_sots_map/featuretype.xml
@@ -1,0 +1,57 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-2a063d6c:1485932beea:7418</id>
+  <name>abos_sots_map</name>
+  <nativeName>abos_sots_map</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>abos_sots_map</title>
+  <keywords>
+    <string>abos_sots_map</string>
+    <string>features</string>
+  </keywords>
+  <metadataLinks>
+    <metadataLink>
+      <type>xml/plain</type>
+      <metadataType>TC211</metadataType>
+      <content>https://catalogue-rc.aodn.org.au/geonetwork/srv/eng/xml_iso19139.mcp?uuid=723a3e85-04ae-40e6-ac2a-237a93d84abe&amp;styleSheet=xml_iso19139.mcp.xsl</content>
+    </metadataLink>
+  </metadataLinks>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>140.6776</minx>
+    <maxx>142.3986</maxx>
+    <miny>-46.9378</miny>
+    <maxy>-46.3224</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>140.6776</minx>
+    <maxx>142.3986</maxx>
+    <miny>-46.9378</miny>
+    <maxy>-46.3224</maxy>
+    <crs>GEOGCS[&quot;WGS84(DD)&quot;, 
+  DATUM[&quot;WGS84&quot;, 
+    SPHEROID[&quot;WGS84&quot;, 6378137.0, 298.257223563]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH]]</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl-2a063d6c:1485932beea:7417</id>
+  </store>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+</featureType>

--- a/workspaces/imos/JNDI_abos_sots/abos_sots_map/layer.xml
+++ b/workspaces/imos/JNDI_abos_sots/abos_sots_map/layer.xml
@@ -1,0 +1,15 @@
+<layer>
+  <name>abos_sots_map</name>
+  <id>LayerInfoImpl-2a063d6c:1485932beea:7419</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-2a063d6c:1485932beea:7418</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_abos_sots/datastore.xml
+++ b/workspaces/imos/JNDI_abos_sots/datastore.xml
@@ -1,0 +1,22 @@
+<dataStore>
+  <id>DataStoreInfoImpl-2a063d6c:1485932beea:7417</id>
+  <name>JNDI_abos_sots</name>
+  <type>PostGIS (JNDI)</type>
+  <enabled>true</enabled>
+  <workspace>
+    <id>WorkspaceInfoImpl-5f0a648d:1428d0d11a9:-8000</id>
+  </workspace>
+  <connectionParameters>
+    <entry key="dbtype">postgis</entry>
+    <entry key="encode functions">false</entry>
+    <entry key="jndiReferenceName">java:comp/env/jdbc/harvest_read</entry>
+    <entry key="namespace">imos.mod</entry>
+    <entry key="schema">abos_sots</entry>
+    <entry key="Loose bbox">true</entry>
+    <entry key="Expose primary keys">false</entry>
+    <entry key="fetch size">1000</entry>
+    <entry key="preparedStatements">false</entry>
+    <entry key="Estimated extends">true</entry>
+  </connectionParameters>
+  <__default>false</__default>
+</dataStore>


### PR DESCRIPTION
This is a new store and new layer for the abos_sots dataset. This
is suppose to replace the old layers/harvesters. A dummy RC record
is link to this layer which will need to be modified before prod.
The harvester needs to be redeployed to RC before reviewing this
layer
