### PR TITLE
content.ftl display 2 images for Southern Surveyor only

### DIFF
--- a/workspaces/imos/JNDI_soop_ba/soop_ba_trajectory_map/content.ftl
+++ b/workspaces/imos/JNDI_soop_ba/soop_ba_trajectory_map/content.ftl
@@ -6,8 +6,16 @@
 <b>Vessel name :</b> ${feature.vessel_name.value}<br/>
 <b>Platform code :</b> ${feature.platform_code.value}<br/>
 <b>Time range :</b> ${feature.time_start.value} - ${feature.time_end.value}<br/>
-
+<#if feature.vessel_name.value =="Southern Surveyor">
+<ul>
+<li> Acoustic data collected at 120kHz </li>
+<img src="${feature.url.value?replace("/mnt/imos-t3/IMOS/opendap/SOOP/SOOP-BA/","http://data.aodn.org.au/IMOS/public/SOOP/BA/")}_120kHz.png"/>
+<li> Acoustic data collected at 38kHz </li>
+<img src="${feature.url.value?replace("/mnt/imos-t3/IMOS/opendap/SOOP/SOOP-BA/","http://data.aodn.org.au/IMOS/public/SOOP/BA/")}_38kHz.png"/>
+</ul>
+<#else>
 <img src="${feature.url.value?replace("/mnt/imos-t3/IMOS/opendap/SOOP/SOOP-BA/","http://data.aodn.org.au/IMOS/public/SOOP/BA/")}.png"/>
+</#if>
 <BR>
 </div>
 </#if>


### PR DESCRIPTION
Small modif to the content ftl to display 2 images for the Southern surveyor only
Please review and merge to production
