### PR TITLE
Update filter column types to be GeoServer types

### DIFF
--- a/workspaces/aodn/AODN_dsto/aodn_dsto_trajectory_data/filters.xml
+++ b/workspaces/aodn/AODN_dsto/aodn_dsto_trajectory_data/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>deployment_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Platform_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aatams_biologging_penguin/aatams_biologging_penguin_data/filters.xml
+++ b/workspaces/imos/JNDI_aatams_biologging_penguin/aatams_biologging_penguin_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>pttid</name>
-    <type>String</type>
+    <type>string</type>
     <label>Animal ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>observation_date</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aatams_biologging_shearwater/aatams_biologging_shearwater_data/filters.xml
+++ b/workspaces/imos/JNDI_aatams_biologging_shearwater/aatams_biologging_shearwater_data/filters.xml
@@ -2,35 +2,35 @@
 <filters>
   <filter>
     <name>animal_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Animal ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>release_date</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Release date</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>release_location</name>
-    <type>String</type>
+    <type>string</type>
     <label>Release site</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>timestamp</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aatams_sattag_dm/aatams_sattag_dm_dive_profile_data/filters.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_dm/aatams_sattag_dm_dive_profile_data/filters.xml
@@ -2,63 +2,63 @@
 <filters>
   <filter>
     <name>age_class</name>
-    <type>String</type>
+    <type>string</type>
     <label>Age class</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>release_site</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment site</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>state_country</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment State/Country</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>device_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sattag_program</name>
-    <type>String</type>
+    <type>string</type>
     <label>Satellite tagging program</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sex</name>
-    <type>String</type>
+    <type>string</type>
     <label>Sex</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>common_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Species name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>tag_type</name>
-    <type>String</type>
+    <type>string</type>
     <label>Tag type</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aatams_sattag_dm/aatams_sattag_dm_haulout_data/filters.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_dm/aatams_sattag_dm_haulout_data/filters.xml
@@ -2,63 +2,63 @@
 <filters>
   <filter>
     <name>age_class</name>
-    <type>String</type>
+    <type>string</type>
     <label>Age class</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>release_site</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment site</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>state_country</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment State/Country</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>device_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sattag_program</name>
-    <type>String</type>
+    <type>string</type>
     <label>Satellite tagging program</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sex</name>
-    <type>String</type>
+    <type>string</type>
     <label>Sex</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>common_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Species name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>tag_type</name>
-    <type>String</type>
+    <type>string</type>
     <label>Tag type</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aatams_sattag_dm/aatams_sattag_dm_location_data/filters.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_dm/aatams_sattag_dm_location_data/filters.xml
@@ -2,70 +2,70 @@
 <filters>
   <filter>
     <name>age_class</name>
-    <type>String</type>
+    <type>string</type>
     <label>Age class</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>release_site</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment site</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>state_country</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment State/Country</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>device_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sattag_program</name>
-    <type>String</type>
+    <type>string</type>
     <label>Satellite tagging program</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sex</name>
-    <type>String</type>
+    <type>string</type>
     <label>Sex</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>common_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Species name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>tag_type</name>
-    <type>String</type>
+    <type>string</type>
     <label>Tag type</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>timestamp</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aatams_sattag_dm/aatams_sattag_dm_profile_data/filters.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_dm/aatams_sattag_dm_profile_data/filters.xml
@@ -2,77 +2,77 @@
 <filters>
   <filter>
     <name>age_class</name>
-    <type>String</type>
+    <type>string</type>
     <label>Age class</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>release_site</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment site</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>state_country</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment State/Country</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>device_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>device_wmo_ref</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device WMO number</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sattag_program</name>
-    <type>String</type>
+    <type>string</type>
     <label>Satellite tagging program</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sex</name>
-    <type>String</type>
+    <type>string</type>
     <label>Sex</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>common_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Species name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>tag_type</name>
-    <type>String</type>
+    <type>string</type>
     <label>Tag type</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>timestamp</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aatams_sattag_dm/aatams_sattag_dm_summary_data/filters.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_dm/aatams_sattag_dm_summary_data/filters.xml
@@ -2,56 +2,56 @@
 <filters>
   <filter>
     <name>age_class</name>
-    <type>String</type>
+    <type>string</type>
     <label>Age class</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>release_site</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment site</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>state_country</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment State/Country</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>device_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sattag_program</name>
-    <type>String</type>
+    <type>string</type>
     <label>Satellite tagging program</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sex</name>
-    <type>String</type>
+    <type>string</type>
     <label>Sex</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>common_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Species name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>tag_type</name>
-    <type>String</type>
+    <type>string</type>
     <label>Tag type</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aatams_sattag_nrt/aatams_sattag_nrt_profile_data/filters.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_nrt/aatams_sattag_nrt_profile_data/filters.xml
@@ -2,77 +2,77 @@
 <filters>
   <filter>
     <name>age_class</name>
-    <type>String</type>
+    <type>string</type>
     <label>Age class</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>release_site</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment site</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>state_country</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment State/Country</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>device_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>device_wmo_ref</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device WMO number</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sattag_program</name>
-    <type>String</type>
+    <type>string</type>
     <label>Satellite tagging program</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sex</name>
-    <type>String</type>
+    <type>string</type>
     <label>Sex</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>common_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Species name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>tag_type</name>
-    <type>String</type>
+    <type>string</type>
     <label>Tag type</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>timestamp</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_abos_currents/abos_currents_map/filters.xml
+++ b/workspaces/imos/JNDI_abos_currents/abos_currents_map/filters.xml
@@ -2,7 +2,7 @@
 <filters>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -11,21 +11,21 @@
   </filter>
   <filter>
     <name>deployment_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>deployment_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>site_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_abos_sofs_fl/abos_sofs_surfaceflux_dm_data/filters.xml
+++ b/workspaces/imos/JNDI_abos_sofs_fl/abos_sofs_surfaceflux_dm_data/filters.xml
@@ -2,7 +2,7 @@
 <filters>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -11,7 +11,7 @@
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_abos_sofs_fl/abos_sofs_surfaceflux_rt_data/filters.xml
+++ b/workspaces/imos/JNDI_abos_sofs_fl/abos_sofs_surfaceflux_rt_data/filters.xml
@@ -2,7 +2,7 @@
 <filters>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -11,7 +11,7 @@
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_abos_sots/abos_sots_map/filters.xml
+++ b/workspaces/imos/JNDI_abos_sots/abos_sots_map/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>data_type</name>
-    <type>String</type>
+    <type>string</type>
     <label>Data product</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>time_coverage_start</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -25,14 +25,14 @@
   </filter>
   <filter>
     <name>deployment_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>deployment_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>platform_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anfog_dm/anfog_dm_trajectory_data/filters.xml
+++ b/workspaces/imos/JNDI_anfog_dm/anfog_dm_trajectory_data/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>deployment_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>deployment_name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_type</name>
-    <type>String</type>
+    <type>string</type>
     <label>platform_type</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anfog_rt/anfog_rt_trajectory_map/filters.xml
+++ b/workspaces/imos/JNDI_anfog_rt/anfog_rt_trajectory_map/filters.xml
@@ -2,35 +2,35 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>deployment_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>deployment_name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_type</name>
-    <type>String</type>
+    <type>string</type>
     <label>platform_type</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>status_filter</name>
-    <type>String</type>
+    <type>string</type>
     <label>Status</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_am_dm/anmn_am_dm_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_am_dm/anmn_am_dm_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Site</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_am_nrt/anmn_am_nrt_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_am_nrt/anmn_am_nrt_data/filters.xml
@@ -2,14 +2,14 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -18,21 +18,21 @@
   </filter>
   <filter>
     <name>deployment_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>deployment_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sea_surface_temperature_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>sea_surface_temperature</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>site_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_ctd_profiles/anmn_ctd_profiles_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_ctd_profiles/anmn_ctd_profiles_data/filters.xml
@@ -2,7 +2,7 @@
 <filters>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -11,14 +11,14 @@
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Site code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_mhlwave/anmn_mhlwave_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_mhlwave/anmn_mhlwave_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Site</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_chemistry_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_chemistry_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>UTC_TRIP_START_TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>STATION_NAME</name>
-    <type>String</type>
+    <type>string</type>
     <label>STATION_NAME</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_phypig_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_phypig_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>UTC_TRIP_START_TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>STATION_NAME</name>
-    <type>String</type>
+    <type>string</type>
     <label>Station Name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_picoplankton_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_picoplankton_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>UTC_TRIP_START_TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>STATION_NAME</name>
-    <type>String</type>
+    <type>string</type>
     <label>Station Name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_plankton_biomass_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_plankton_biomass_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>UTC_TRIP_START_TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>STATION_NAME</name>
-    <type>String</type>
+    <type>string</type>
     <label>Station Name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_plankton_phytoplankton_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_plankton_phytoplankton_data/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>UTC_TRIP_START_TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TAXON_ECO_GROUP</name>
-    <type>String</type>
+    <type>string</type>
     <label>Functional group</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>STATION_NAME</name>
-    <type>String</type>
+    <type>string</type>
     <label>Station Name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_plankton_zooplankton_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_plankton_zooplankton_data/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>UTC_TRIP_START_TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TAXON_ECO_GROUP</name>
-    <type>String</type>
+    <type>string</type>
     <label>Functional group</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>STATION_NAME</name>
-    <type>String</type>
+    <type>string</type>
     <label>Station Name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_tss_secchi_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_nrs_bgc/anmn_nrs_bgc_tss_secchi_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>UTC_TRIP_START_TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>STATION_NAME</name>
-    <type>String</type>
+    <type>string</type>
     <label>Station Name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_nrs_dar_yon/anmn_nrs_yon_dar_timeseries_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_nrs_dar_yon/anmn_nrs_yon_dar_timeseries_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>platform_name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -25,7 +25,7 @@
   </filter>
   <filter>
     <name>VARNAME</name>
-    <type>String</type>
+    <type>string</type>
     <label>Variable name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_anmn_t_regridded/anmn_regridded_temperature_data/filters.xml
+++ b/workspaces/imos/JNDI_anmn_t_regridded/anmn_regridded_temperature_data/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>DEPTH</name>
-    <type>Float</type>
+    <type>decimal</type>
     <label>Depth</label>
     <visualised>false</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Site</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aodn_nt_sattag_hawksbill/aodn_nt_sattag_hawksbill_dive_profile_data/filters.xml
+++ b/workspaces/imos/JNDI_aodn_nt_sattag_hawksbill/aodn_nt_sattag_hawksbill_dive_profile_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>device_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sattag_program</name>
-    <type>String</type>
+    <type>string</type>
     <label>Satellite tagging program</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aodn_nt_sattag_hawksbill/aodn_nt_sattag_hawksbill_haulout_data/filters.xml
+++ b/workspaces/imos/JNDI_aodn_nt_sattag_hawksbill/aodn_nt_sattag_hawksbill_haulout_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>device_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sattag_program</name>
-    <type>String</type>
+    <type>string</type>
     <label>Satellite tagging program</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aodn_nt_sattag_hawksbill/aodn_nt_sattag_hawksbill_location_data/filters.xml
+++ b/workspaces/imos/JNDI_aodn_nt_sattag_hawksbill/aodn_nt_sattag_hawksbill_location_data/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>device_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sattag_program</name>
-    <type>String</type>
+    <type>string</type>
     <label>Satellite tagging program</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>timestamp</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aodn_nt_sattag_hawksbill/aodn_nt_sattag_hawksbill_profile_data/filters.xml
+++ b/workspaces/imos/JNDI_aodn_nt_sattag_hawksbill/aodn_nt_sattag_hawksbill_profile_data/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>device_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sattag_program</name>
-    <type>String</type>
+    <type>string</type>
     <label>Satellite tagging program</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>timestamp</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_aodn_nt_sattag_hawksbill/aodn_nt_sattag_hawksbill_summary_data/filters.xml
+++ b/workspaces/imos/JNDI_aodn_nt_sattag_hawksbill/aodn_nt_sattag_hawksbill_summary_data/filters.xml
@@ -2,14 +2,14 @@
 <filters>
   <filter>
     <name>device_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Device ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sattag_program</name>
-    <type>String</type>
+    <type>string</type>
     <label>Satellite tagging program</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_auv/auv_trajectory_st_data/filters.xml
+++ b/workspaces/imos/JNDI_auv/auv_trajectory_st_data/filters.xml
@@ -2,63 +2,63 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>campaign_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Campaign name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>CPHL_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Chlorophyll</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>CDOM_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Colored dissolved organic matter (CDOM)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>dive_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Dive name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>OPBS_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Optical Backscattering (OPBS)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>PSAL_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Salinity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TEMP_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Temperature</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_cpr/aad_so_cpr_map/filters.xml
+++ b/workspaces/imos/JNDI_cpr/aad_so_cpr_map/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>position</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>species_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Species name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>date_time</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>ship_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Vessel code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_dbprod_harvest_abos_sofs_sp/abos_sofs_surfaceprop_dm_data/filters.xml
+++ b/workspaces/imos/JNDI_dbprod_harvest_abos_sofs_sp/abos_sofs_surfaceprop_dm_data/filters.xml
@@ -2,14 +2,14 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_dbprod_harvest_abos_sofs_sp/abos_sofs_surfaceprop_rt_data/filters.xml
+++ b/workspaces/imos/JNDI_dbprod_harvest_abos_sofs_sp/abos_sofs_surfaceprop_rt_data/filters.xml
@@ -2,14 +2,14 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -18,7 +18,7 @@
   </filter>
   <filter>
     <name>deployment_number</name>
-    <type>String</type>
+    <type>string</type>
     <label>deployment_number</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_dbprod_harvest_abos_ts/abos_ts_timeseries_data/filters.xml
+++ b/workspaces/imos/JNDI_dbprod_harvest_abos_ts/abos_ts_timeseries_data/filters.xml
@@ -2,7 +2,7 @@
 <filters>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -11,35 +11,35 @@
   </filter>
   <filter>
     <name>deployment_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>deployment_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>platform_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sea_water_salinity_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Salinity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>site_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_dbprod_harvest_anmn_burst_avg/anmn_burst_avg_timeseries_data/filters.xml
+++ b/workspaces/imos/JNDI_dbprod_harvest_anmn_burst_avg/anmn_burst_avg_timeseries_data/filters.xml
@@ -2,7 +2,7 @@
 <filters>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -11,21 +11,21 @@
   </filter>
   <filter>
     <name>deployment_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Site code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_dbprod_harvest_anmn_nrs_rt_bio/anmn_nrs_rt_bio_timeseries_data/filters.xml
+++ b/workspaces/imos/JNDI_dbprod_harvest_anmn_nrs_rt_bio/anmn_nrs_rt_bio_timeseries_data/filters.xml
@@ -2,7 +2,7 @@
 <filters>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -11,14 +11,14 @@
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Site code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_dbprod_harvest_anmn_nrs_rt_meteo/anmn_nrs_rt_meteo_timeseries_data/filters.xml
+++ b/workspaces/imos/JNDI_dbprod_harvest_anmn_nrs_rt_meteo/anmn_nrs_rt_meteo_timeseries_data/filters.xml
@@ -2,7 +2,7 @@
 <filters>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -11,14 +11,14 @@
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Site code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_dbprod_harvest_anmn_nrs_rt_wave/anmn_nrs_rt_wave_timeseries_data/filters.xml
+++ b/workspaces/imos/JNDI_dbprod_harvest_anmn_nrs_rt_wave/anmn_nrs_rt_wave_timeseries_data/filters.xml
@@ -2,7 +2,7 @@
 <filters>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -11,14 +11,14 @@
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Site code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_dbprod_harvest_anmn_ts/anmn_ts_timeseries_data/filters.xml
+++ b/workspaces/imos/JNDI_dbprod_harvest_anmn_ts/anmn_ts_timeseries_data/filters.xml
@@ -2,7 +2,7 @@
 <filters>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -11,35 +11,35 @@
   </filter>
   <filter>
     <name>deployment_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>deployment_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>platform_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>sea_water_salinity_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Salinity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>site_code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_dbprod_harvest_anmn_velocity/anmn_velocity_timeseries_map/filters.xml
+++ b/workspaces/imos/JNDI_dbprod_harvest_anmn_velocity/anmn_velocity_timeseries_map/filters.xml
@@ -2,7 +2,7 @@
 <filters>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -11,21 +11,21 @@
   </filter>
   <filter>
     <name>deployment_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Deployment code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Site code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_faimms/faimms_timeseries_data/filters.xml
+++ b/workspaces/imos/JNDI_faimms/faimms_timeseries_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Platform name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -25,7 +25,7 @@
   </filter>
   <filter>
     <name>VARNAME</name>
-    <type>String</type>
+    <type>string</type>
     <label>Variable name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_noaa_drifters/noaa_drifters_data/filters.xml
+++ b/workspaces/imos/JNDI_noaa_drifters/noaa_drifters_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>date_utc</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Date (UTC)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>driftnum</name>
-    <type>Long</type>
+    <type>decimal</type>
     <label>Drifter ID</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_asf_mft/soop_asf_mft_trajectory_data/filters.xml
+++ b/workspaces/imos/JNDI_soop_asf_mft/soop_asf_mft_trajectory_data/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>cruise_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Cruise id</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Platform code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -32,7 +32,7 @@
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Vessel name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_asf_mt/soop_asf_mt_trajectory_data/filters.xml
+++ b/workspaces/imos/JNDI_soop_asf_mt/soop_asf_mt_trajectory_data/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>cruise_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Cruise id</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Platform code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -32,7 +32,7 @@
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Vessel name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_pci_trajectory_map/filters.xml
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_pci_trajectory_map/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>vessel name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_trajectory_map/filters.xml
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_trajectory_map/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>taxon_group</name>
-    <type>String</type>
+    <type>string</type>
     <label>Taxonomic Classification</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Vessel name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_trajectory_map/filters.xml
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_trajectory_map/filters.xml
@@ -2,35 +2,35 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>taxon_group</name>
-    <type>String</type>
+    <type>string</type>
     <label>Taxonomic Classification</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>taxon_eco_group</name>
-    <type>String</type>
+    <type>string</type>
     <label>Taxonomic group</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Vessel name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_ba/soop_ba_trajectory_map/filters.xml
+++ b/workspaces/imos/JNDI_soop_ba/soop_ba_trajectory_map/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Platform code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -25,7 +25,7 @@
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Vessel name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_co2/soop_co2_trajectory_data/filters.xml
+++ b/workspaces/imos/JNDI_soop_co2/soop_co2_trajectory_data/filters.xml
@@ -2,21 +2,21 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>cruise_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>cruise_id</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -25,7 +25,7 @@
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>vessel_name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_sst/soop_sst_dm_trajectory_data/filters.xml
+++ b/workspaces/imos/JNDI_soop_sst/soop_sst_dm_trajectory_data/filters.xml
@@ -2,70 +2,70 @@
 <filters>
   <filter>
     <name>AIRT_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Air temperature</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>ATMP_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Atmospheric pressure</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>WDIR_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Earth-relative wind direction</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>WSPD_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Earth-relative wind speed</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>RAD_PAR_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Photosynthetically active radiation</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Platform code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>RELH_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Relative humidity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TEMP_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Sea temperature</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -74,14 +74,14 @@
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Vessel name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>voyage_number</name>
-    <type>String</type>
+    <type>string</type>
     <label>Voyage number</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_sst/soop_sst_nrt_trajectory_data/filters.xml
+++ b/workspaces/imos/JNDI_soop_sst/soop_sst_nrt_trajectory_data/filters.xml
@@ -2,91 +2,91 @@
 <filters>
   <filter>
     <name>AIRT_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Air temperature</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>ATMP_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Atmospheric pressure</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>DEWT_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Dew-point temperature</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>WDIR_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Earth-relative wind direction</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>WSPD_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Earth-relative wind speed</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>platform_code</name>
-    <type>String</type>
+    <type>string</type>
     <label>Platform code</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>PL_WDIR_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Platform relative wind direction</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>PL_WSPD_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Platform relative wind speed</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>RELH_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Relative humidity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>PSAL_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Sea salinity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TEMP_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Sea temperature</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -95,14 +95,14 @@
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Vessel name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>WETT_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Wet-bulb temperature</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_tmv/soop_tmv_trajectory_data/filters.xml
+++ b/workspaces/imos/JNDI_soop_tmv/soop_tmv_trajectory_data/filters.xml
@@ -2,35 +2,35 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>CNDC_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Conductivity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>PSAL_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Salinity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TEMP_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Temperature</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -39,14 +39,14 @@
   </filter>
   <filter>
     <name>TURB_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Turbidity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>vessel_name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_tmv_nrt/soop_tmv_nrt_trajectory_data/filters.xml
+++ b/workspaces/imos/JNDI_soop_tmv_nrt/soop_tmv_nrt_trajectory_data/filters.xml
@@ -2,14 +2,14 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_trv/soop_trv_trajectory_data/filters.xml
+++ b/workspaces/imos/JNDI_soop_trv/soop_trv_trajectory_data/filters.xml
@@ -2,35 +2,35 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>fluorescence_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Fluorescence</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>PSAL_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Salinity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>Seawater_Intake_Temperature_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Temperature</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>time</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -39,14 +39,14 @@
   </filter>
   <filter>
     <name>TURB_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Turbidity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Vessel name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_xbt_dm/soop_xbt_dm_profile_data/filters.xml
+++ b/workspaces/imos/JNDI_soop_xbt_dm/soop_xbt_dm_profile_data/filters.xml
@@ -2,35 +2,35 @@
 <filters>
   <filter>
     <name>Callsign</name>
-    <type>String</type>
+    <type>string</type>
     <label>Callsign</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>XBT_line</name>
-    <type>String</type>
+    <type>string</type>
     <label>XBT line</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>XBT_line_description</name>
-    <type>String</type>
+    <type>string</type>
     <label>XBT line description</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_soop_xbt_nrt/soop_xbt_nrt_profiles_data/filters.xml
+++ b/workspaces/imos/JNDI_soop_xbt_nrt/soop_xbt_nrt_profiles_data/filters.xml
@@ -2,35 +2,35 @@
 <filters>
   <filter>
     <name>Callsign</name>
-    <type>String</type>
+    <type>string</type>
     <label>Callsign</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>geom</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>Timestamp</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Vessel name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>XBT_line</name>
-    <type>String</type>
+    <type>string</type>
     <label>XBT line</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_srs_altimetry/srs_altimetry_timeseries_data/filters.xml
+++ b/workspaces/imos/JNDI_srs_altimetry/srs_altimetry_timeseries_data/filters.xml
@@ -2,70 +2,70 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>CNDC_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Conductivity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>UCUR_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Current (horizontal component)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>VCUR_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Current (vertical component)</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>instrument</name>
-    <type>String</type>
+    <type>string</type>
     <label>instrument</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>PRES_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Pressure</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>PSAL_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Salinity</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>site_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>site name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TEMP_b</name>
-    <type>Boolean</type>
+    <type>boolean</type>
     <label>Temperature</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_srs_oc_bodbaw/srs_oc_bodbaw_trajectory_profile_map/filters.xml
+++ b/workspaces/imos/JNDI_srs_oc_bodbaw/srs_oc_bodbaw_trajectory_profile_map/filters.xml
@@ -2,28 +2,28 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>cruise_id</name>
-    <type>String</type>
+    <type>string</type>
     <label>Cruise Identifier</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>data_type</name>
-    <type>String</type>
+    <type>string</type>
     <label>Data Type</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -32,7 +32,7 @@
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>Vessel Name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>

--- a/workspaces/imos/JNDI_srs_oc_soop_rad/srs_oc_soop_rad_trajectory_map/filters.xml
+++ b/workspaces/imos/JNDI_srs_oc_soop_rad/srs_oc_soop_rad_trajectory_map/filters.xml
@@ -2,14 +2,14 @@
 <filters>
   <filter>
     <name>geom</name>
-    <type>Geometry</type>
+    <type>geometrypropertytype</type>
     <label>Bounding Box</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
     <name>TIME</name>
-    <type>DateRange</type>
+    <type>datetime</type>
     <label>Time</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>
@@ -18,7 +18,7 @@
   </filter>
   <filter>
     <name>vessel_name</name>
-    <type>String</type>
+    <type>string</type>
     <label>vessel name</label>
     <visualised>true</visualised>
     <excludedFromDownload>false</excludedFromDownload>


### PR DESCRIPTION
This updates the existing filter configs so that they have GeoServer column types rather than Portal types.

@jkburges This should fix the errors we saw yesterday when running against GeoServer.