### PR TITLE
Ignore files which geoserver can sometimes change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ security/usergroup/default/users.xml
 *.iml
 Thumbs.db
 gwc-layers/*
+global.xml
+wfs.xml
 


### PR DESCRIPTION
The documentation for harvester deployment has a note about making sure not to check in global.xml and wfs.xml: https://docs.google.com/document/d/1-E05wDMvI_Yy2Zz9m3D8DCWUjjkhPDJFm_jr9TvbUgc/edit#heading=h.oh3lu3aq0r4q

This change means that that note can be deleted (because someone would have to go expressly out of their way to do check in a change to either of these files).