### PR TITLE
NOAA Drifters - create new style to fix missing hits

### DIFF
--- a/styles/noaa_drifters.sld
+++ b/styles/noaa_drifters.sld
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<StyledLayerDescriptor xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.0.0" xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.0.0/StyledLayerDescriptor.xsd">
+  <NamedLayer>
+    <Name>noaa_drifters</Name>
+    <UserStyle>
+      <Title>A blue line style</Title>
+      <FeatureTypeStyle>
+        <Rule>
+          <Title>blue line</Title>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#FFFFFF</CssParameter>
+              <CssParameter name="stroke-opacity">0.01</CssParameter>
+              <CssParameter name="stroke-width">50</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+          <LineSymbolizer>
+            <Stroke>
+              <CssParameter name="stroke">#0000FF</CssParameter>
+              <CssParameter name="stroke-width">2</CssParameter>
+            </Stroke>
+          </LineSymbolizer>
+        </Rule>
+      </FeatureTypeStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>

--- a/styles/noaa_drifters.xml
+++ b/styles/noaa_drifters.xml
@@ -1,0 +1,9 @@
+<style>
+  <id>StyleInfoImpl-46f88ab3:153870446c9:275d</id>
+  <name>noaa_drifters</name>
+  <format>sld</format>
+  <languageVersion>
+    <version>1.0.0</version>
+  </languageVersion>
+  <filename>noaa_drifters.sld</filename>
+</style>

--- a/workspaces/imos/JNDI_noaa_drifters/noaa_drifters_map/featuretype.xml
+++ b/workspaces/imos/JNDI_noaa_drifters/noaa_drifters_map/featuretype.xml
@@ -49,16 +49,19 @@
         <enabled>false</enabled>
       </dimensionInfo>
     </entry>
-    <entry key="cachingEnabled">false</entry>
     <entry key="elevation">
       <dimensionInfo>
         <enabled>false</enabled>
       </dimensionInfo>
     </entry>
+    <entry key="cachingEnabled">false</entry>
   </metadata>
   <store class="dataStore">
     <id>DataStoreInfoImpl-263bac4c:1446c91c7e3:-73f7</id>
   </store>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
 </featureType>

--- a/workspaces/imos/JNDI_noaa_drifters/noaa_drifters_map/layer.xml
+++ b/workspaces/imos/JNDI_noaa_drifters/noaa_drifters_map/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl-263bac4c:1446c91c7e3:-73f5</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-7fff</id>
+    <id>StyleInfoImpl-46f88ab3:153870446c9:275d</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl-263bac4c:1446c91c7e3:-73f6</id>


### PR DESCRIPTION
 * creation of a big and fat line (50pixels) around the main one with an
   opacity value of 0.01 (fine tuning as small than that, and it doesnt
   work, doesnt make sense but thats how it is). One can now click on a
   track and getfeature info back