### PR TITLE
remove faulty cndc filter generate errors in geoserver

### DIFF
--- a/workspaces/imos/JNDI_soop_tmv/soop_tmv_trajectory_data/filters.xml
+++ b/workspaces/imos/JNDI_soop_tmv/soop_tmv_trajectory_data/filters.xml
@@ -8,13 +8,6 @@
     <excludedFromDownload>false</excludedFromDownload>
   </filter>
   <filter>
-    <name>CNDC_b</name>
-    <type>boolean</type>
-    <label>Conductivity</label>
-    <visualised>true</visualised>
-    <excludedFromDownload>false</excludedFromDownload>
-  </filter>
-  <filter>
     <name>PSAL_b</name>
     <type>boolean</type>
     <label>Salinity</label>


### PR DESCRIPTION
@lbesnard I changed my mind since this morning.  I'm getting rid of the faulty filter option for now, and keep in mind (on a sticky note) that we had a problem with this one
