### PR TITLE
Revert "Use argo data default style for additional argo primary profile layers"

### DIFF
--- a/workspaces/imos/JNDI_argo/argo_primary_profile_bio_high_res_data/layer.xml
+++ b/workspaces/imos/JNDI_argo/argo_primary_profile_bio_high_res_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl-4065b3ef:15aa1683ab1:66b2</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+    <id>StyleInfoImpl--28ae9436:15722231f36:-7ffb</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl-4065b3ef:15aa1683ab1:66b1</id>

--- a/workspaces/imos/JNDI_argo/argo_primary_profile_core_low_res_good_qc_data/layer.xml
+++ b/workspaces/imos/JNDI_argo/argo_primary_profile_core_low_res_good_qc_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl-4065b3ef:15aa14e7420:-7ebb</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+    <id>StyleInfoImpl--28ae9436:15722231f36:-7ffb</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl-4065b3ef:15aa14e7420:-7ebc</id>

--- a/workspaces/imos/JNDI_argo/argo_primary_profile_merged_low_res_good_qc_data/layer.xml
+++ b/workspaces/imos/JNDI_argo/argo_primary_profile_merged_low_res_good_qc_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl-4065b3ef:15aa1683ab1:66b4</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+    <id>StyleInfoImpl--28ae9436:15722231f36:-7ffb</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl-4065b3ef:15aa1683ab1:66b3</id>

--- a/workspaces/imos/JNDI_argo/argo_sec_profiles_core_high_res_good_qc_data/layer.xml
+++ b/workspaces/imos/JNDI_argo/argo_sec_profiles_core_high_res_good_qc_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--5d653b32:15aa182ad2d:4420</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+    <id>StyleInfoImpl--28ae9436:15722231f36:-7ffb</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--5d653b32:15aa182ad2d:-7804</id>


### PR DESCRIPTION
Reverts aodn/geoserver-config#442

Jenkins is not currently able to merge master->production, so reverting this. Since the changes *are* actually in master, they will be included in the next prod merge