### PR TITLE
Remove image with faulty filename

### DIFF
--- a/styles/dart_float.sld
+++ b/styles/dart_float.sld
@@ -10,7 +10,7 @@
   <PointSymbolizer>
      <Graphic>
        <ExternalGraphic>
-          <OnlineResource xlink:type="simple" xlink:href="ring_buoy.png?" />
+          <OnlineResource xlink:type="simple" xlink:href="ring_buoy.png" />
           <Format>image/png</Format>
        </ExternalGraphic>
        <Size>20</Size>


### PR DESCRIPTION
Filenames shouldn't contain the character '?'  and there's already another file with the name ring_buoy.png