### PR TITLE
Change default type of lat/lon min/max aggregation overrides to Double

### DIFF
--- a/wps/default.xml
+++ b/wps/default.xml
@@ -4,9 +4,9 @@
     <attribute name="time_coverage_start" type="String" value="${TIME_START}"/>
     <attribute name="time_coverage_end" type="String" value="${TIME_END}"/>
     <attribute name="title" match="(.*?)(,[^,]*)?" type="String" value="${1}, ${TIME_START}, ${TIME_END}"/>
-    <attribute name="geospatial_lat_min" type="String" value="${LAT_MIN}"/>
-    <attribute name="geospatial_lat_max" type="String" value="${LAT_MAX}"/>
-    <attribute name="geospatial_lon_min" type="String" value="${LON_MIN}"/>
-    <attribute name="geospatial_lon_max" type="String" value="${LON_MAX}"/>
+    <attribute name="geospatial_lat_min" type="Double" value="${LAT_MIN}"/>
+    <attribute name="geospatial_lat_max" type="Double" value="${LAT_MAX}"/>
+    <attribute name="geospatial_lon_min" type="Double" value="${LON_MIN}"/>
+    <attribute name="geospatial_lon_max" type="Double" value="${LON_MAX}"/>
   </attributes>
 </template>

--- a/wps/templates.xml
+++ b/wps/templates.xml
@@ -96,16 +96,16 @@
                 <ac:name>title</ac:name><ac:type>String</ac:type><ac:match>(.*?)(,[^,]*)?</ac:match><ac:value>${1}, ${TIME_START}, ${TIME_END}</ac:value>
             </ac:attribute>
             <ac:attribute>
-                <ac:name>geospatial_lat_min</ac:name><ac:type>String</ac:type><ac:value>${LAT_MIN}</ac:value>
+                <ac:name>geospatial_lat_min</ac:name><ac:type>Double</ac:type><ac:value>${LAT_MIN}</ac:value>
             </ac:attribute>
             <ac:attribute>
-                <ac:name>geospatial_lat_max</ac:name><ac:type>String</ac:type><ac:value>${LAT_MAX}</ac:value>
+                <ac:name>geospatial_lat_max</ac:name><ac:type>Double</ac:type><ac:value>${LAT_MAX}</ac:value>
             </ac:attribute>
             <ac:attribute>
-                <ac:name>geospatial_lon_min</ac:name><ac:type>String</ac:type><ac:value>${LON_MIN}</ac:value>
+                <ac:name>geospatial_lon_min</ac:name><ac:type>Double</ac:type><ac:value>${LON_MIN}</ac:value>
             </ac:attribute>
             <ac:attribute>
-                <ac:name>geospatial_lon_max</ac:name><ac:type>String</ac:type><ac:value>${LON_MAX}</ac:value>
+                <ac:name>geospatial_lon_max</ac:name><ac:type>Double</ac:type><ac:value>${LON_MAX}</ac:value>
             </ac:attribute>
         </ac:attributes>
     </ac:template>


### PR DESCRIPTION
Fixes https://github.com/aodn/geoserver-build/issues/228

Defaulting to a number type rather than String conforms to the [ IMOS NETCDF conventions](https://s3-ap-southeast-2.amazonaws.com/content.aodn.org.au/Documents/IMOS/Conventions/IMOS_NetCDF_Conventions.pdf),
