### PR TITLE
feat(gridded-timeseries): add layer config

### DIFF
--- a/global.xml
+++ b/global.xml
@@ -27,6 +27,32 @@
     <jpegAcceleration>false</jpegAcceleration>
     <allowNativeMosaic>false</allowNativeMosaic>
     <allowNativeWarp>false</allowNativeWarp>
+    <jaiext>
+      <jaiExtOperations class="sorted-set">
+        <string>Affine</string>
+        <string>BandCombine</string>
+        <string>BandMerge</string>
+        <string>BandSelect</string>
+        <string>Binarize</string>
+        <string>Border</string>
+        <string>ColorConvert</string>
+        <string>Crop</string>
+        <string>ErrorDiffusion</string>
+        <string>Format</string>
+        <string>ImageFunction</string>
+        <string>Lookup</string>
+        <string>Mosaic</string>
+        <string>Null</string>
+        <string>OrderedDither</string>
+        <string>Rescale</string>
+        <string>Scale</string>
+        <string>Stats</string>
+        <string>Translate</string>
+        <string>Warp</string>
+        <string>algebric</string>
+        <string>operationConst</string>
+      </jaiExtOperations>
+    </jaiext>
   </jai>
   <coverageAccess>
     <maxPoolSize>5</maxPoolSize>
@@ -35,7 +61,7 @@
     <queueType>UNBOUNDED</queueType>
     <imageIOCacheThreshold>10240</imageIOCacheThreshold>
   </coverageAccess>
-  <updateSequence>83</updateSequence>
+  <updateSequence>93</updateSequence>
   <featureTypeCacheSize>0</featureTypeCacheSize>
   <globalServices>true</globalServices>
   <xmlPostRequestLogBufferSize>1024</xmlPostRequestLogBufferSize>

--- a/gwc-gs.xml
+++ b/gwc-gs.xml
@@ -1,13 +1,27 @@
 <GeoServerGWCConfig>
-  <version>1.0.0</version>
-  <directWMSIntegrationEnabled>false</directWMSIntegrationEnabled>
+  <version>1.1.0</version>
+  <directWMSIntegrationEnabled>true</directWMSIntegrationEnabled>
   <WMSCEnabled>true</WMSCEnabled>
-  <WMTSEnabled>true</WMTSEnabled>
   <TMSEnabled>true</TMSEnabled>
+  <securityEnabled>false</securityEnabled>
+  <innerCachingEnabled>false</innerCachingEnabled>
+  <persistenceEnabled>false</persistenceEnabled>
+  <cacheProviderClass>class org.geowebcache.storage.blobstore.memory.guava.GuavaCacheProvider</cacheProviderClass>
+  <cacheConfigurations>
+    <entry>
+      <string>class org.geowebcache.storage.blobstore.memory.guava.GuavaCacheProvider</string>
+      <InnerCacheConfiguration>
+        <hardMemoryLimit>16</hardMemoryLimit>
+        <policy>NULL</policy>
+        <concurrencyLevel>4</concurrencyLevel>
+        <evictionTime>120</evictionTime>
+      </InnerCacheConfiguration>
+    </entry>
+  </cacheConfigurations>
   <cacheLayersByDefault>true</cacheLayersByDefault>
-  <cacheNonDefaultStyles>true</cacheNonDefaultStyles>
-  <metaTilingX>4</metaTilingX>
-  <metaTilingY>4</metaTilingY>
+  <cacheNonDefaultStyles>false</cacheNonDefaultStyles>
+  <metaTilingX>3</metaTilingX>
+  <metaTilingY>3</metaTilingY>
   <gutter>0</gutter>
   <defaultCachingGridSetIds>
     <string>EPSG:4326</string>
@@ -15,14 +29,12 @@
   </defaultCachingGridSetIds>
   <defaultCoverageCacheFormats>
     <string>image/png</string>
-    <string>image/jpeg</string>
   </defaultCoverageCacheFormats>
   <defaultVectorCacheFormats>
     <string>image/png</string>
-    <string>image/jpeg</string>
   </defaultVectorCacheFormats>
   <defaultOtherCacheFormats>
     <string>image/png</string>
-    <string>image/jpeg</string>
   </defaultOtherCacheFormats>
+  <lockProviderName>nioLock</lockProviderName>
 </GeoServerGWCConfig>

--- a/gwc/geowebcache.xml
+++ b/gwc/geowebcache.xml
@@ -1,154 +1,96 @@
-<?xml version="1.0" encoding="utf-8"?>
-<gwcConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xmlns="http://geowebcache.org/schema/1.3.0"
-  xsi:schemaLocation="http://geowebcache.org/schema/1.3.0 http://geowebcache.org/schema/1.3.0/geowebcache.xsd">
-  <version>1.3.0</version>
-  <backendTimeout>120</backendTimeout>
-  <!--
-  <serviceInformation>
-    <title>GeoWebCache</title>
-    <description>GeoWebCache is an advanced tile cache for WMS servers.It supports a large variety of protocols and
-      formats, including WMS-C, WMTS, KML, Google Maps and Virtual Earth.</description>
-    <keywords>
-      <string>WFS</string>
-      <string>WMS</string>
-      <string>WMTS</string>
-      <string>GEOWEBCACHE</string>
-    </keywords>
-    <serviceProvider>
-      <providerName>John Smith inc.</providerName>
-      <providerSite>http://www.example.com/</providerSite>
-      <serviceContact>
-        <individualName>John Smith</individualName>
-        <positionName>Geospatial Expert</positionName>
-        <addressType>Work</addressType>
-        <addressStreet>1 Bumpy St.</addressStreet>
-        <addressCity>Hobart</addressCity>
-        <addressAdministrativeArea>TAS</addressAdministrativeArea>
-        <addressPostalCode>7005</addressPostalCode>
-        <addressCountry>Australia</addressCountry>
-        <phoneNumber>+61 3 0000 0000</phoneNumber>
-        <faxNumber>+61 3 0000 0001</faxNumber>
-        <addressEmail>john.smith@example.com</addressEmail>
-      </serviceContact>
-    </serviceProvider>
-    <fees>NONE</fees>
-    <accessConstraints>NONE</accessConstraints>
-  </serviceInformation>
-  -->
-  <gridSets>
-    <!-- Grid Set Example, by default EPSG:900913 and EPSG:4326 are defined -->
-    <!--
-    <gridSet>
-      <name>EPSG:2163</name>
-      <srs>
-        <number>2163</number>
-      </srs>
-      <extent>
-        <coords>
-          <double>-2495667.977678598</double>
-          <double>-2223677.196231552</double>
-          <double>3291070.6104286816</double>
-          <double>959189.3312465074</double>
-        </coords>
-      </extent>
-      <scaleDenominators>
-        <double>25000000</double>
-        <double>1000000</double>
-        <double>100000</double>
-        <double>25000</double>
-      </scaleDenominators>
-      <tileHeight>200</tileHeight>
-      <tileWidth>200</tileWidth>
-    </gridSet>
-    -->
-  </gridSets>
+<?xml version="1.0" encoding="utf-8"?><gwcConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xmlns="http://geowebcache.org/schema/1.10.0"
+                  xsi:schemaLocation="http://geowebcache.org/schema/1.10.0 http://geowebcache.org/schema/1.10.0/geowebcache.xsd">
+    <version>1.8.0</version>
+    <backendTimeout>180</backendTimeout>
+    <lockProvider>nioLock</lockProvider>
+    <serviceInformation>
+        <title>GeoWebCache</title>
+        <description>GeoWebCache is an advanced tile cache for WMS servers. It supports a large variety of protocols and
+            formats, including WMS-C, WMTS, KML, Google Maps and Virtual Earth.
+        </description>
+        <keywords>
+            <string>WFS</string>
+            <string>WMS</string>
+            <string>WMTS</string>
+            <string>GEOWEBCACHE</string>
+        </keywords>
 
-  <layers>
-    <!--
-    <wmsLayer>
-      <name>topp:states</name>
-      <mimeFormats>
-        <string>image/gif</string>
-        <string>image/jpeg</string>
-        <string>image/png</string>
-        <string>image/png8</string>
-      </mimeFormats>
-      <gridSubsets>
-        <gridSubset>
-          <gridSetName>EPSG:2163</gridSetName>
-        </gridSubset>
-      </gridSubsets>
-      <parameterFilters>
-        <stringParameterFilter>
-          <key>STYLES</key>
-          <defaultValue>population</defaultValue>
-          <values>
-            <string>population</string>
-            <string>polygon</string>
-            <string>usflags</string>
-            <string>pophatch</string>
-          </values>
-        </stringParameterFilter>
-      </parameterFilters>
-      <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
-      </wmsUrl>
-    </wmsLayer>
+        <serviceProvider>
+            <providerName>Australian Ocean Data Network</providerName>
+            <providerSite>http://aodn.org.au</providerSite>
+            <serviceContact>
+                <addressType>Work</addressType>
+                <addressStreet>Private Bag 110</addressStreet>
+                <addressCity>Hobart</addressCity>
+                <addressAdministrativeArea>TAS</addressAdministrativeArea>
+                <addressPostalCode>7005</addressPostalCode>
+                <addressCountry>Australia</addressCountry>
+                <phoneNumber>+61 3 6226 7549</phoneNumber>
+                <faxNumber>+61 3 6226 2107</faxNumber>
+                <addressEmail>info@aodn.org.au</addressEmail>
+            </serviceContact>
+        </serviceProvider>
+        <fees>NONE</fees>
+        <accessConstraints>NONE</accessConstraints>
+    </serviceInformation><blobStores>
+        <S3BlobStore default="true">
+            <id>CacheBucket</id>
+            <enabled>true</enabled>
+            <bucket>aodnstack-holiveira2-geoservercache</bucket>
+            <prefix></prefix>
+            <awsAccessKey></awsAccessKey>
+            <awsSecretKey></awsSecretKey>
+            <access>PUBLIC</access>
+            <maxConnections>50</maxConnections>
+            <useHTTPS>true</useHTTPS>
+            <useGzip>false</useGzip>
+        </S3BlobStore>
 
-    <wmsLayer>
-      <name>raster test layer</name>
-      <mimeFormats>
-        <string>image/gif</string>
-        <string>image/jpeg</string>
-        <string>image/png</string>
-        <string>image/png8</string>
-      </mimeFormats>
-      <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
-      </wmsUrl>
-      <wmsLayers>nurc:Img_Sample</wmsLayers>
-    </wmsLayer>
+    </blobStores>
 
-    <wmsLayer>
-      <name>img states</name>
-      <metaInformation>
-        <title>Nicer title for Image States</title>
-        <description>This is a description. Fascinating.</description>
-      </metaInformation>
-      <mimeFormats>
-        <string>image/gif</string>
-        <string>image/jpeg</string>
-        <string>image/png</string>
-        <string>image/png8</string>
-      </mimeFormats>
-      <gridSubsets>
-        <gridSubset>
-          <gridSetName>EPSG:4326</gridSetName>
-          <extent>
-            <coords>
-              <double>-129.6</double>
-              <double>3.45</double>
-              <double>-62.1</double>
-              <double>70.9</double>
-            </coords>
-          </extent>
-        </gridSubset>
-      </gridSubsets>
-      <expireCacheList>
-        <expirationRule minZoom="0" expiration="60" />
-      </expireCacheList>
-      <expireClientsList>
-        <expirationRule minZoom="0" expiration="500" />
-      </expireClientsList>
-      <wmsUrl>
-        <string>http://demo.opengeo.org/geoserver/wms</string>
-      </wmsUrl>
-      <wmsLayers>nurc:Img_Sample,topp:states</wmsLayers>
-      <transparent>false</transparent>
-      <bgColor>0x0066FF</bgColor>
-    </wmsLayer>
-    -->
-  </layers>
-  
+    <gridSets>
+        <gridSet>
+            <name>EPSG:4326</name>
+            <description>A default WGS84 tile matrix set where the first zoom level covers the world with two tiles
+                on the horizonal axis and one tile over the vertical axis and each subsequent zoom level is calculated
+                by half the resolution of its previous one.
+            </description>
+            <srs>
+                <number>4326</number>
+            </srs>
+            <extent>
+                <coords>
+                    <double>-180.0</double>
+                    <double>-90.0</double>
+                    <double>180.0</double>
+                    <double>90.0</double>
+                </coords>
+            </extent>
+            <alignTopLeft>false</alignTopLeft>
+            <resolutions>
+                <double>1.40625</double>   <!-- whole world in one tile (used by online resource monitor)-->
+                <double>0.703125</double>
+                <double>0.3515625</double>   <!-- portal first -->
+                <double>0.17578125</double>
+                <double>0.087890625</double>
+                <double>0.0439453125</double>
+                <double>0.02197265625</double>
+                <double>0.010986328125</double>
+                <double>0.0054931640625</double>
+                <double>0.00274658203125</double>
+                <double>0.001373291015625</double>
+                <double>6.866455078125E-4</double>
+                <double>3.433227539062E-4</double>
+                <double>1.716613769531E-4</double> <!-- last -->
+            </resolutions>
+            <metersPerUnit>111319.49079327358</metersPerUnit>
+            <pixelSize>2.8E-4</pixelSize>
+            <tileHeight>256</tileHeight>
+            <tileWidth>256</tileWidth>
+
+            <yCoordinateFirst>false</yCoordinateFirst>
+        </gridSet>
+    </gridSets>
+
 </gwcConfiguration>

--- a/ncwms.xml
+++ b/ncwms.xml
@@ -1,4 +1,4 @@
 <ncwms>
   <wfsServer>http://localhost:8080/geoserver/ows</wfsServer>
-  <urlSubstitution key="^">http://thredds.aodn.org.au/thredds/wms/</urlSubstitution>
+  <urlSubstitution key="^">http://thredds-aodnstack-holiveira2.dev.aodn.org.au/thredds/wms/</urlSubstitution>
 </ncwms>

--- a/security/filter/exception/config.xml
+++ b/security/filter/exception/config.xml
@@ -2,5 +2,4 @@
   <id>-3a52b6b4:1428ce0125d:-7feb</id>
   <name>exception</name>
   <className>org.geoserver.security.filter.GeoServerExceptionTranslationFilter</className>
-  <accessDeniedErrorPage>/accessDenied.jsp</accessDeniedErrorPage>
 </exceptionTranslation>

--- a/workspaces/config.ftl
+++ b/workspaces/config.ftl
@@ -1,7 +1,10 @@
-<#assign baseurl = "https://geoserver-rc.aodn.org.au/geoserver" >
+
 <#assign baseMetadataShow = "https://catalogue-rc.aodn.org.au/geonetwork/srv/en/metadata.show?uuid=" >
+
 <#assign baseurlDataServer = "https://imos-data.s3-ap-southeast-2.amazonaws.com" >
+
 <#assign baseurlDataServerS3Listing = "http://imos-data.s3-website-ap-southeast-2.amazonaws.com/?prefix=" >
+
 <#assign baseurlStaticImages = "https://static.emii.org.au/images/portalImages" >
-<!--#assign insertpage = "aims.freemarker.directives.InsertPageDirective"?new() -->
-<#assign baseurlThredds = "http://thredds.aodn.org.au" >
+
+<#assign baseurlThredds = "http://thredds-aodnstack-holiveira2.dev.aodn.org.au" >


### PR DESCRIPTION
this is the gridded_timeseries layer in geoserver tested with ```IMOS_ANMN-NRS_SZ_20081120_NRSROT_FV02_PSAL-gridded-timeseries_END-20190523_C-20191121.nc```
and metadata record  ```http://catalogue-rc.aodn.org.au/geonetwork/srv/en/metadata.show?uuid=279a50e3-21a5-4590-85a0-71f963efab82```


The file is not properly loaded in the database - the LON/LAT are zero. The actual file only got metadata lon/lat ranges.

The layer is OK but the icon is only rendered at the equator (0/0 deg).

