### PR TITLE
Re-enable wms on AUV Images layer

### DIFF
--- a/workspaces/imos/JNDI_auv_viewer/auv_images_vw/featuretype.xml
+++ b/workspaces/imos/JNDI_auv_viewer/auv_images_vw/featuretype.xml
@@ -48,10 +48,6 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl-219289c1:1497999d21a:-6cf6</id>
   </store>
-  <serviceConfiguration>true</serviceConfiguration>
-  <disabledServices>
-    <string>WMS</string>
-  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <overridingServiceSRS>false</overridingServiceSRS>


### PR DESCRIPTION
This layer is used by the AUV app for mapping tiles so needs WMS access

Should fix https://github.com/aodn/issues/issues/664