### PR TITLE
SRS OC - add generic_timestep layers

### DIFF
--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_K_490/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_K_490/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fff</id>
+  <name>srs_oc_aqua_K_490</name>
+  <nativeName>srs_oc_aqua_K_490</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_K_490</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_K_490</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_K_490</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_K_490&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_K_490/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_K_490/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_K_490</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7ffe</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fff</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_gsm/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_gsm/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ffd</id>
+  <name>srs_oc_aqua_chl_gsm</name>
+  <nativeName>srs_oc_aqua_chl_gsm</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_chl_gsm</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_chl_gsm</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_chl_gsm</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_chl_gsm&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_gsm/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_gsm/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_chl_gsm</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7ffc</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ffd</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_oc3/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_oc3/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ffb</id>
+  <name>srs_oc_aqua_chl_oc3</name>
+  <nativeName>srs_oc_aqua_chl_oc3</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_chl_oc3</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_chl_oc3</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_chl_oc3</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_chl_oc3&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_oc3/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_oc3/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_chl_oc3</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7ffa</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ffb</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_oci/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_oci/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ff9</id>
+  <name>srs_oc_aqua_chl_oci</name>
+  <nativeName>srs_oc_aqua_chl_oci</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_chl_oci</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_chl_oci</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_chl_oci</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_chl_oci&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_oci/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_chl_oci/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_chl_oci</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7ff8</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ff9</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_dt/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_dt/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ff7</id>
+  <name>srs_oc_aqua_dt</name>
+  <nativeName>srs_oc_aqua_dt</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_dt</title>
+  <keywords>
+    <string>srs_oc_aqua_dt</string>
+    <string>features</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_dt</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_dt&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_dt/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_dt/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_dt</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7ff6</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ff7</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_ipar/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_ipar/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ff5</id>
+  <name>srs_oc_aqua_ipar</name>
+  <nativeName>srs_oc_aqua_ipar</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_ipar</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_ipar</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_ipar</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_ipar&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_ipar/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_ipar/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_ipar</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7ff4</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ff5</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_l2_flags/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_l2_flags/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ff3</id>
+  <name>srs_oc_aqua_l2_flags</name>
+  <nativeName>srs_oc_aqua_l2_flags</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_l2_flags</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_l2_flags</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_l2_flags</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_l2_flags&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_l2_flags/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_l2_flags/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_l2_flags</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7ff2</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ff3</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_nanop_brewin2010at/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_nanop_brewin2010at/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ff1</id>
+  <name>srs_oc_aqua_nanop_brewin2010at</name>
+  <nativeName>srs_oc_aqua_nanop_brewin2010at</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_nanop_brewin2010at</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_nanop_brewin2010at</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_nanop_brewin2010at</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_nanop_brewin2010at&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_nanop_brewin2010at/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_nanop_brewin2010at/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_nanop_brewin2010at</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7ff0</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7ff1</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_nanop_brewin2012in/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_nanop_brewin2012in/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fef</id>
+  <name>srs_oc_aqua_nanop_brewin2012in</name>
+  <nativeName>srs_oc_aqua_nanop_brewin2012in</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_nanop_brewin2012in</title>
+  <keywords>
+    <string>srs_oc_aqua_nanop_brewin2012in</string>
+    <string>features</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_nanop_brewin2012in</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_nanop_brewin2012in&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_nanop_brewin2012in/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_nanop_brewin2012in/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_nanop_brewin2012in</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7fee</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fef</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_npp_vgpm_eppley_gsm/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_npp_vgpm_eppley_gsm/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fed</id>
+  <name>srs_oc_aqua_npp_vgpm_eppley_gsm</name>
+  <nativeName>srs_oc_aqua_npp_vgpm_eppley_gsm</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_npp_vgpm_eppley_gsm</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_npp_vgpm_eppley_gsm</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_npp_vgpm_eppley_gsm</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_npp_vgpm_eppley_gsm&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_npp_vgpm_eppley_gsm/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_npp_vgpm_eppley_gsm/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_npp_vgpm_eppley_gsm</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7fec</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fed</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_npp_vgpm_eppley_oc3/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_npp_vgpm_eppley_oc3/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7feb</id>
+  <name>srs_oc_aqua_npp_vgpm_eppley_oc3</name>
+  <nativeName>srs_oc_aqua_npp_vgpm_eppley_oc3</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_npp_vgpm_eppley_oc3</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_npp_vgpm_eppley_oc3</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_npp_vgpm_eppley_oc3</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_npp_vgpm_eppley_oc3&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_npp_vgpm_eppley_oc3/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_npp_vgpm_eppley_oc3/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_npp_vgpm_eppley_oc3</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7fea</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7feb</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_owtd/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_owtd/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fe9</id>
+  <name>srs_oc_aqua_owtd</name>
+  <nativeName>srs_oc_aqua_owtd</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_owtd</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_owtd</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_owtd</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_owtd&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_owtd/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_owtd/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_owtd</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7fe8</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fe9</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_par/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_par/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fe7</id>
+  <name>srs_oc_aqua_par</name>
+  <nativeName>srs_oc_aqua_par</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_par</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_par</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_par</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_par&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_par/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_par/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_par</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7fe6</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fe7</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_picop_brewin2010at/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_picop_brewin2010at/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fe5</id>
+  <name>srs_oc_aqua_picop_brewin2010at</name>
+  <nativeName>srs_oc_aqua_picop_brewin2010at</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_picop_brewin2010at</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_picop_brewin2010at</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_picop_brewin2010at</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_picop_brewin2010at&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_picop_brewin2010at/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_picop_brewin2010at/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_picop_brewin2010at</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7fe4</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fe5</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_picop_brewin2012in/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_picop_brewin2012in/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fe3</id>
+  <name>srs_oc_aqua_picop_brewin2012in</name>
+  <nativeName>srs_oc_aqua_picop_brewin2012in</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_picop_brewin2012in</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_picop_brewin2012in</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_picop_brewin2012in</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_picop_brewin2012in&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_picop_brewin2012in/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_picop_brewin2012in/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_picop_brewin2012in</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7fe2</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fe3</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_sst/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_sst/featuretype.xml
@@ -1,0 +1,43 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fe1</id>
+  <name>srs_oc_aqua_sst</name>
+  <nativeName>srs_oc_aqua_sst</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_sst</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_sst</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_sst</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_sst&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_sst/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_sst/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_sst</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7fe0</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fe1</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_sst_quality/featuretype.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_sst_quality/featuretype.xml
@@ -1,0 +1,50 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fdf</id>
+  <name>srs_oc_aqua_sst_quality</name>
+  <nativeName>srs_oc_aqua_sst_quality</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_aqua_sst_quality</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_aqua_sst_quality</string>
+  </keywords>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-1.0</minx>
+    <maxx>0.0</maxx>
+    <miny>-1.0</miny>
+    <maxy>0.0</maxy>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>srs_oc_aqua_sst_quality</name>
+        <sql>select timestep_id, collection_name, file_url, size, &quot;TIME&quot; as time from generic_timestep.timestep_url where collection_name = &apos;srs_oc_aqua_sst_quality&apos;
+</sql>
+        <escapeSql>false</escapeSql>
+      </virtualTable>
+    </entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--5360df55:155d8796886:-7dbc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_sst_quality/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_oc_aqua_sst_quality/layer.xml
@@ -1,0 +1,12 @@
+<layer>
+  <name>srs_oc_aqua_sst_quality</name>
+  <id>LayerInfoImpl-4734fe9e:17470dad9eb:-7fde</id>
+  <type>VECTOR</type>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-4734fe9e:17470dad9eb:-7fdf</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>


### PR DESCRIPTION
17 new products using the generic timestep  schema, to be used with gogoduck, all configured with

<srs>EPSG:4326</srs>
 <minx>-180.0</minx>
  <maxx>180.0</maxx>
  <miny>-90.0</miny>
  <maxy>90.0</maxy>