### PR TITLE
New flat_map layers for soop_auscpr

### DIFF
--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_flat_map/content.ftl
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_flat_map/content.ftl
@@ -1,0 +1,7 @@
+<p>Data are available in analysis-ready (absences included, taxonomic changes managed), raw or binned (taxonomic group, genus, species) abundance products at the download stage.</p>
+
+<p><b>The data products downloadable here are a sample only and are not updated with new data or changes in taxonomy.</b> Infrastructure to update and maintain the products is being developed.
+In the meantime, updated products can be requested by contacting <a href="mailto:imos-plankton@csiro.au">imos-plankton@csiro.au</a>. All products are also available in bio-volume instead of abundance on request.</p> 
+
+<p>The latest raw data can be downloaded in "flat table" form (separate row for each taxon in each sample) on Step 3.</p>
+

--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_flat_map/featuretype.xml
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_flat_map/featuretype.xml
@@ -1,0 +1,53 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-7fb687d:17500894a09:-7ffd</id>
+  <name>soop_auscpr_phyto_flat_map</name>
+  <nativeName>soop_auscpr_phyto_flat_map</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>soop_auscpr_phyto_flat_map</title>
+  <keywords>
+    <string>features</string>
+    <string>soop_auscpr_phyto_flat_map</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl-4e226e20:14603675f99:-7ff3</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_flat_map/filters.xml
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_flat_map/filters.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<filters>
+    <filter>
+        <name>SampleDateUTC</name>
+        <type>datetime</type>
+        <label>SampleDateUTC</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>geom</name>
+        <type>geometrypropertytype</type>
+        <label>Geom</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+</filters>

--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_flat_map/layer.xml
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_flat_map/layer.xml
@@ -1,0 +1,20 @@
+<layer>
+  <name>soop_auscpr_phyto_flat_map</name>
+  <id>LayerInfoImpl-7fb687d:17500894a09:-7ffc</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl-1186b25e:1674d1d3893:-7fe7</id>
+  </defaultStyle>
+  <styles class="linked-hash-set">
+    <style>
+      <id>StyleInfoImpl-1b043e60:13164ec07c0:-7ffd</id>
+    </style>
+  </styles>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-7fb687d:17500894a09:-7ffd</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_flat_map/content.ftl
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_flat_map/content.ftl
@@ -1,0 +1,7 @@
+<p>Data are available in analysis-ready (absences included, taxonomic changes managed), raw or binned (taxonomic group, genus, species) abundance products at the download stage.</p>
+
+<p><b>The data products downloadable here are a sample only and are not updated with new data or changes in taxonomy.</b> Infrastructure to update and maintain the products is being developed.
+In the meantime, updated products can be requested by contacting <a href="mailto:imos-plankton@csiro.au">imos-plankton@csiro.au</a>. All products are also available in bio-volume instead of abundance on request.</p> 
+
+<p>The latest raw data can be downloaded in "flat table" form (separate row for each taxon in each sample) on Step 3.</p>
+

--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_flat_map/featuretype.xml
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_flat_map/featuretype.xml
@@ -1,0 +1,53 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-7fb687d:17500894a09:-7ffa</id>
+  <name>soop_auscpr_zoop_flat_map</name>
+  <nativeName>soop_auscpr_zoop_flat_map</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>soop_auscpr_zoop_flat_map</title>
+  <keywords>
+    <string>features</string>
+    <string>soop_auscpr_zoop_flat_map</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl-4e226e20:14603675f99:-7ff3</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_flat_map/filters.xml
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_flat_map/filters.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<filters>
+    <filter>
+        <name>SampleDateUTC</name>
+        <type>datetime</type>
+        <label>SampleDateUTC</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>geom</name>
+        <type>geometrypropertytype</type>
+        <label>Geom</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+</filters>

--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_flat_map/layer.xml
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_flat_map/layer.xml
@@ -1,0 +1,20 @@
+<layer>
+  <name>soop_auscpr_zoop_flat_map</name>
+  <id>LayerInfoImpl-7fb687d:17500894a09:-7ff9</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl-1186b25e:1674d1d3893:-7fe7</id>
+  </defaultStyle>
+  <styles class="linked-hash-set">
+    <style>
+      <id>StyleInfoImpl-1b043e60:13164ec07c0:-7ffc</id>
+    </style>
+  </styles>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-7fb687d:17500894a09:-7ffa</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>


### PR DESCRIPTION
The purpose of these layers is to provide the plankton data in "flat" (unpivoted) form alongside the pivoted plankton products (which can't be updated now). They have the same metadata columns and same filters as the pivoted layers.

The new views are available in dbprod, so this is ready to be merged.

Part of https://github.com/aodn/PO-Backlog/issues/1287