### PR TITLE
Fix invalid layers and add Github Actions validation check

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,17 @@
+name: Validate config
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ '**' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run validation tests
+        run: docker-compose run dev ./test.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM ubuntu:16.04
 
 ARG BUILDER_UID=9999
-ARG PACKER_VERSION=1.4.2
 
 ENV LANG C.UTF-8
-ENV PATH /opt/packer:$PATH
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 	expat \
+	python3 \
     && rm -rf /var/lib/apt/lists/*
 
 RUN useradd --create-home --no-log-init --shell /bin/bash --uid $BUILDER_UID builder

--- a/bin/validate_layers.py
+++ b/bin/validate_layers.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+from xml.etree import ElementTree
+
+
+# TODO: validate styles?
+# TODO: other layer validation functions?
+
+# These '*_data' layers are permitted to have WMS enabled
+# elements are a 2-tuple with the format: (workspace, layer_name)
+WMS_DATA_LAYERS = {
+    ('aodn', 'aodn_dsto_trajectory_data'),
+    ('aodn', 'aodn_wamsi_sediment_data'),
+    ('aodn', 'cleveland_bay_data'),
+    ('aodn', 'JBmeteorological_data'),
+    ('aodn', 'JBoceanographic_data'),
+    ('aodn', 'new_south_wales_coastal_data'),
+    ('aodn', 'south_australian_coastal_data'),
+    ('aodn', 'spencer_gulf_oceanographic_data'),
+    ('imos', 'aus_chla_db_data'),
+    ('imos', 'csiro_data'),
+    ('imos', 'imos_data'),
+    ('imos', 'marvl3_atlas_data'),
+    ('imos', 'marvl3_raw_data'),
+    ('imos', 'wod_data')
+}
+
+
+#
+# VALIDATION FUNCTIONS
+#
+
+class ValidationError(Exception):
+    pass
+
+
+def validate_layer_default_style(layer, styles, raise_on_missing=False):
+    """Validator to check for a valid defaultStyle tag
+
+    :param layer: layer to validate
+    :param styles: list of *valid* styles
+    :return: None
+    """
+    if layer.style in styles:
+        # style is valid
+        return
+
+    if layer.style.id is None:
+        if not raise_on_missing:
+            return
+        status_message = "missing defaultStyle tag".format(layer=layer)
+    else:
+        status_message = "references nonexistent style: {layer.style.id}".format(layer=layer)
+    raise ValidationError(status_message)
+
+
+def validate_layer_services(layer, styles):
+    """Validator to check that WMS is disabled for _data layers, unless explicitly whitelisted in WMS_DATA_LAYERS
+
+    :param layer: layer to validate
+    :param styles: list of *valid* styles
+    :return: None
+    """
+
+    # not a _data layer
+    if not layer.name.endswith('_data'):
+        return
+
+    # has been whitelisted
+    if (layer.workspace, layer.name) in WMS_DATA_LAYERS:
+        return
+
+    # WMS is disabled
+    if 'WMS' in layer.featuretype.disabled_services:
+        return
+
+    raise ValidationError("WMS must be disabled for _data layers")
+
+
+# validator function references added to this list will be included in overall validation of each layer object
+# functions must accept two parameters: the Layer object being validated, and the list of all styles
+ALL_LAYER_VALIDATORS = [
+    validate_layer_default_style,
+    validate_layer_services
+]
+
+
+#
+# CONFIGURATION OBJECTS
+#
+
+class Layer(object):
+    """Represents a layer.xml file in a Geoserver config workspace
+    """
+
+    def __init__(self, name, style, featuretype, datastore, workspace, xml_file_path):
+        self.name = name
+        self.style = style
+        self.featuretype = featuretype
+        self.datastore = datastore
+        self.workspace = workspace
+        self.xml_file_path = xml_file_path
+
+        self.errors = []
+
+    def __repr__(self):
+        return ("{s.__class__.__name__}(name='{s.name}', style={s.style}, datastore={s.datastore}, "
+                "workspace={s.workspace},invalid_message={s.invalid_message}, "
+                "xml_file_path='{s.xml_file_path}')").format(s=self)
+
+    def __str__(self):
+        return "{s.workspace}:{s.name} - errors:'{s.errors}'".format(s=self)
+
+    @classmethod
+    def from_xml_file(cls, xml_file):
+        """Construct from XML file path
+
+        :param xml_file: path to layer.xml
+        :return: new instance
+        """
+        root = ElementTree.parse(xml_file)
+        style = Style(root.findtext('./defaultStyle/id'), root.findtext('./defaultStyle/name'))
+        featuretype_path = os.path.join(os.path.dirname(xml_file), 'featuretype.xml')
+        featuretype = FeatureType.from_xml_file(featuretype_path)
+        path_info = get_path_info_from_layer_xml_path(xml_file)
+        return cls(root.findtext('./name'), style, featuretype, path_info['datastore'], path_info['workspace'],
+                   xml_file)
+
+
+class Style(object):
+    """Represents a style XML file in a Geoserver config directory
+    """
+
+    def __init__(self, id_, name):
+        self.id = id_
+        self.name = name
+
+    def __eq__(self, other):
+        return self.id == other.id
+
+    def __hash__(self):
+        return hash(self.id)
+
+    def __repr__(self):
+        return "{s.__class__.__name__}(id={id}, name={name})".format(s=self,
+                                                                     id=quote_string_if_not_none(self.id),
+                                                                     name=quote_string_if_not_none(self.name))
+
+    @classmethod
+    def from_xml_file(cls, xml_file):
+        """Construct from XML file path
+
+        :param xml_file: path to style XML file
+        :return: new instance
+        """
+        root = ElementTree.parse(xml_file)
+        return cls(root.findtext('./id'), root.findtext('./name'))
+
+
+class FeatureType(object):
+    """Represents a featuretype.xml file in a Geoserver config directory
+    """
+
+    def __init__(self, id_, disabled_services):
+        self.id = id_
+        self.disabled_services = disabled_services
+
+    @classmethod
+    def from_xml_file(cls, xml_file):
+        """Construct from XML file path
+
+        :param xml_file: path to featuretype.xml
+        :return: new instance
+        """
+        root = ElementTree.parse(xml_file)
+        raw_disabled_services = root.find('./disabledServices')
+        disabled_services = [] if raw_disabled_services is None else [e.text
+                                                                      for e in raw_disabled_services.findall('string')]
+        return cls(root.findtext('./id'), disabled_services)
+
+
+#
+# UTILITY FUNCTIONS
+#
+
+def quote_string_if_not_none(string_, quote="'"):
+    """Return a quoted string, or None.
+
+    :param string_: input string
+    :param quote: quote character
+    :return: quoted string, or bare None
+    """
+    return string_ if string_ is None else "{quote}{string}{quote}".format(string=string_, quote=quote)
+
+
+def find_layer_xml_files(workspace_dir):
+    """Recursively find all layer.xml files in a directory
+
+    :param workspace_dir: directory to walk
+    :return: list of paths layer.xml files
+    """
+    layer_xml_files = []
+    for root, dirs, files in os.walk(workspace_dir):
+        layer_xml_files.extend(os.path.join(root, name) for name in files if name == 'layer.xml')
+    return layer_xml_files
+
+
+def find_style_xml_files(root_dir):
+    """Recursively find all style XML files, by including all XMl files inside a directory named 'styles'
+
+    :param root_dir: directory to walk
+    :return: list of paths to style XML files
+    """
+    style_xml_files = []
+    for root, dirs, files in os.walk(root_dir):
+        if os.path.basename(root) == 'styles':
+            style_xml_files.extend(os.path.join(root, name) for name in files if name.endswith('.xml'))
+    return style_xml_files
+
+
+def get_path_info_from_layer_xml_path(layer_xml):
+    """Get the datastore and workspace of a layer.xml file by traversing back up the path
+
+    :param layer_xml: full path to a layer.xml file
+    :return: workspace in which the layer.xml resides
+    """
+    datastore_dir = os.path.dirname(os.path.dirname(layer_xml))
+    datastore = os.path.basename(datastore_dir)
+    workspace = os.path.basename(os.path.dirname(datastore_dir))
+    return {
+        'datastore': datastore,
+        'workspace': workspace
+    }
+
+
+def load_layers(workspace_dir):
+    """Load all layer.xml into a set of Layer objects
+
+    :param workspace_dir: directory to walk
+    :return: set containing a Layer instance for each layer.xml file found
+    """
+    layer_xml_files = find_layer_xml_files(workspace_dir)
+    return {Layer.from_xml_file(layer_xml) for layer_xml in layer_xml_files}
+
+
+def load_styles(root_dir):
+    """Load all styles into a set of Style objects
+
+    :param root_dir: directory to walk
+    :return: set containing a Style object for each XML file found
+    """
+    xml_files = find_style_xml_files(root_dir)
+    return {Style.from_xml_file(x) for x in xml_files}
+
+
+def validate_layer(layer, styles):
+    """Validate a Layer instance
+
+    :param layer: Layer instance to validate
+    :param styles: collection of all valid styles
+    :return: None
+    """
+    for validate in ALL_LAYER_VALIDATORS:
+        try:
+            validate(layer, styles)
+        except ValidationError as e:
+            layer.errors.append(e)
+
+
+def validate_layers(layers, styles):
+    """Validate a sequence of layers
+
+    :param layers: sequence of layers to validate
+    :param styles: sequence of valid styles
+    :return: tuple containing two lists, with the first being valid layers and the second being invalid layers
+    """
+    valid_layers = []
+    invalid_layers = []
+
+    for layer in layers:
+        validate_layer(layer, styles)
+        if layer.errors:
+            invalid_layers.append(layer)
+        else:
+            valid_layers.append(layer)
+
+    return valid_layers, invalid_layers
+
+
+def get_layer_summary(valid_layers, invalid_layers):
+    """Get a summary report on invalid layers, showing counts and printing details of invalid layers
+
+    :param valid_layers: list of valid layers
+    :param invalid_layers: list of invalid layers
+    :return: string containing report text
+    """
+    lines = [
+        "VALID LAYERS COUNT: {}".format(len(valid_layers)),
+        "INVALID LAYERS COUNT: {}".format(len(invalid_layers)),
+        'INVALID LAYERS:'
+    ]
+    lines.extend(("  {}".format(str(l)) for l in invalid_layers))
+    return os.linesep.join(lines)
+
+
+#
+# COMMAND-LINE INTERFACE
+#
+
+def argparse_type_existing_dir(dir_):
+    if os.path.isdir(dir_):
+        return dir_
+    raise argparse.ArgumentTypeError("invalid geoserver-config directory '{dir}'".format(dir=dir_))
+
+
+def cli():
+    """Command line entry point
+
+    :return: None
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument('geoserver_config_dir',
+                        metavar='geoserver-config-dir',
+                        type=argparse_type_existing_dir,
+                        help='Path to a geoserver-config directory')
+    args = parser.parse_args()
+
+    all_layers = load_layers(os.path.join(args.geoserver_config_dir, 'workspaces'))
+    all_styles = load_styles(args.geoserver_config_dir)
+
+    valid_layers, invalid_layers = validate_layers(all_layers, all_styles)
+    print(get_layer_summary(valid_layers, invalid_layers))
+
+    if invalid_layers:
+        parser.exit(1)
+
+
+if __name__ == '__main__':
+    cli()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+
+services:
+  dev:
+    image: geonetwork-config-test
+    build:
+      context: .
+      args:
+        BUILDER_UID: 1000
+    stdin_open: true
+    tty: true
+    working_dir: /app
+    volumes:
+      - './:/app'

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+HERE=$(dirname $(readlink -f $0))
+
 # Checking well formed local xml files
 tmp_output=$(mktemp)
 trap "rm -f $tmp_output" EXIT
@@ -12,6 +14,8 @@ if [ $retval -ne 0 ]; then
     cat $tmp_output
     exit 1
 fi
+
+$HERE/bin/validate_layers.py $HERE
 
 exit 0
 

--- a/workspaces/depth/legacy_bathy/world_depth_data/layer.xml
+++ b/workspaces/depth/legacy_bathy/world_depth_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--771c575a:1624bcb83e0:-7ffa</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl--61363ae4:1624bb8f2b9:-7ffd</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--771c575a:1624bcb83e0:-7ffb</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_dive_profile_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_dive_profile_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fea</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_dive_profile_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_dive_profile_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7fb6</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7fb7</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_haulout_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_haulout_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fea</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_haulout_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_haulout_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7fb4</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7fb5</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_location_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_location_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fea</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_location_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_location_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7fb2</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7fb3</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_profile_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_profile_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fea</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_profile_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_profile_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7fb0</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7fb1</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_ssm_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_ssm_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fea</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_ssm_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_ssm_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7fae</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7faf</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_summary_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_summary_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fea</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_summary_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_dm/aatams_sattag_qc_dm_summary_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7fac</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7fad</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_dive_profile_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_dive_profile_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fff</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_dive_profile_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_dive_profile_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7ff3</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7ff4</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_haulout_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_haulout_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fff</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_haulout_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_haulout_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7ff1</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7ff2</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_location_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_location_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fff</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_location_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_location_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7fef</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7ff0</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_profile_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_profile_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fff</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_profile_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_profile_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7ff5</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7ff6</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_ssm_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_ssm_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fff</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_ssm_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_ssm_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7fed</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7fee</id>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_summary_data/featuretype.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_summary_data/featuretype.xml
@@ -37,7 +37,10 @@
   <store class="dataStore">
     <id>DataStoreInfoImpl--50450070:172df4afacb:-7fff</id>
   </store>
-  <serviceConfiguration>false</serviceConfiguration>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
   <maxFeatures>0</maxFeatures>
   <numDecimals>0</numDecimals>
   <padWithZeros>false</padWithZeros>

--- a/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_summary_data/layer.xml
+++ b/workspaces/imos/JNDI_aatams_sattag_qc_nrt/aatams_sattag_qc_nrt_summary_data/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--50450070:172df4afacb:-7feb</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl-78ecace6:172df45d804:-8000</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--50450070:172df4afacb:-7fec</id>

--- a/workspaces/imos/JNDI_generic_timestep/csiro_cars_monthly_url/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/csiro_cars_monthly_url/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--5360df55:155d8796886:-7db6</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl--396ecd48:155a40f3d82:-7ffc</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--5360df55:155d8796886:-7db7</id>

--- a/workspaces/imos/JNDI_generic_timestep/csiro_cars_weekly_url/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/csiro_cars_weekly_url/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--5360df55:155d8796886:-7db8</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl--396ecd48:155a40f3d82:-7ffc</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--5360df55:155d8796886:-7db9</id>

--- a/workspaces/imos/JNDI_generic_timestep/srs_ghrsst_l3s_1d_day_url/layer.xml
+++ b/workspaces/imos/JNDI_generic_timestep/srs_ghrsst_l3s_1d_day_url/layer.xml
@@ -3,7 +3,7 @@
   <id>LayerInfoImpl--7b175bdd:159b4e6e1f3:124d</id>
   <type>VECTOR</type>
   <defaultStyle>
-    <id>StyleInfoImpl--28ae9436:15722231f36:-7ffb</id>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
   </defaultStyle>
   <resource class="featureType">
     <id>FeatureTypeInfoImpl--7b175bdd:159b4e6e1f3:124c</id>


### PR DESCRIPTION
This follows on from (and largely resolves) these issues by adding a simple validation check (which can be expanded upon as required), and fixing the currently invalid layers:

https://github.com/aodn/geoserver-config/issues/435
https://github.com/aodn/content/issues/383

The fixes should be verified by POs before merging, but they should just be following the current conventions for other data layers which we consider to be "valid":

* data layers are assigned the default `point` style to avoid "invalid style" errors
* data layers should have WMS disabled (unless they are explicitly whitelisted in the validation script), to prevent useless and very expensive requests made in an attempt to visualise them

