### PR TITLE
Remove outdated plankton products from SOOP CPR collections

### DIFF
--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_flat_map/content.ftl
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_phyto_flat_map/content.ftl
@@ -1,7 +1,7 @@
-<p>Data are available in analysis-ready (absences included, taxonomic changes managed), raw or binned (taxonomic group, genus, species) abundance products at the download stage.</p>
 
-<p><b>The data products downloadable here are a sample only and are not updated with new data or changes in taxonomy.</b> Infrastructure to update and maintain the products is being developed.
-In the meantime, updated products can be requested by contacting <a href="mailto:imos-plankton@csiro.au">imos-plankton@csiro.au</a>. All products are also available in bio-volume instead of abundance on request.</p> 
+<p>This collection currently provides the latest raw data only in "flat table" form (separate row for each taxon in each sample).</p>
 
-<p>The latest raw data can be downloaded in "flat table" form (separate row for each taxon in each sample) on Step 3.</p>
+<p>These data are also available in analysis-ready (absences included, taxonomic changes managed), raw or binned (taxonomic group, genus, species) abundance products by contacting <a href="mailto:imos-plankton@csiro.au">imos-plankton@csiro.au</a>. All products are also available in bio-volume instead of abundance on request.
+
+<p>A project to make these products available directly via the portal is under way.</p>
 

--- a/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_flat_map/content.ftl
+++ b/workspaces/imos/JNDI_soop_auscpr/soop_auscpr_zoop_flat_map/content.ftl
@@ -1,7 +1,7 @@
-<p>Data are available in analysis-ready (absences included, taxonomic changes managed), raw or binned (taxonomic group, genus, species) abundance products at the download stage.</p>
 
-<p><b>The data products downloadable here are a sample only and are not updated with new data or changes in taxonomy.</b> Infrastructure to update and maintain the products is being developed.
-In the meantime, updated products can be requested by contacting <a href="mailto:imos-plankton@csiro.au">imos-plankton@csiro.au</a>. All products are also available in bio-volume instead of abundance on request.</p> 
+<p>This collection currently provides the latest raw data only in "flat table" form (separate row for each taxon in each sample).</p>
 
-<p>The latest raw data can be downloaded in "flat table" form (separate row for each taxon in each sample) on Step 3.</p>
+<p>These data are also available in analysis-ready (absences included, taxonomic changes managed), raw or binned (taxonomic group, genus, species) abundance products by contacting <a href="mailto:imos-plankton@csiro.au">imos-plankton@csiro.au</a>. All products are also available in bio-volume instead of abundance on request.
+
+<p>A project to make these products available directly via the portal is under way.</p>
 


### PR DESCRIPTION
Update content.ftl for the SOOP CPR plankton layers to remove mention of the "sample" out-of-date products.

This is for https://github.com/aodn/PO-Backlog/issues/1715