### PR TITLE
Update IMOS_LOGGING.properties

### DIFF
--- a/logs/IMOS_LOGGING.properties
+++ b/logs/IMOS_LOGGING.properties
@@ -5,7 +5,7 @@ log4j.rootLogger=WARN, stdout
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{dd MMM HH:mm:ss} %p [%c{2}] - %m%n
+log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} %p [%c{2}] - %m%n
 
 
 log4j.category.log4j=FATAL


### PR DESCRIPTION
Change the log file date format to ISO8601 compliant ISO8601 format (yyyy-MM-dd HH:mm:ss.SSS)

Relates to issue: https://github.com/aodn/issues/issues/987