### PR TITLE
Octopus project: add new _data layer for  depth binned ctd product

### DIFF
--- a/workspaces/imos/JNDI_imos_bgc_db/nrs_depth_binned_ctd_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/nrs_depth_binned_ctd_data/featuretype.xml
@@ -1,0 +1,71 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-47e1658:17dc02c5512:-7ffc</id>
+  <name>nrs_depth_binned_ctd_data</name>
+  <nativeName>nrs_depth_binned_ctd_data</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>nrs_depth_binned_ctd_data</title>
+  <keywords>
+    <string>features</string>
+    <string>nrs_depth_binned_ctd_data</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>nrs_depth_binned_ctd_data</name>
+        <sql>SELECT *&#xd;
+FROM imos_bgc_db.nrs_depth_binned_ctd_data&#xd;
+ORDER BY &quot;TripCode&quot;
+</sql>
+        <escapeSql>false</escapeSql>
+        <geometry>
+          <name>geom</name>
+          <type>Point</type>
+          <srid>4326</srid>
+        </geometry>
+      </virtualTable>
+    </entry>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--22c97b22:17b283bfd43:-7fff</id>
+  </store>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_imos_bgc_db/nrs_depth_binned_ctd_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/nrs_depth_binned_ctd_data/featuretype.xml
@@ -42,7 +42,7 @@
         <name>nrs_depth_binned_ctd_data</name>
         <sql>SELECT *&#xd;
 FROM imos_bgc_db.nrs_depth_binned_ctd_data&#xd;
-ORDER BY &quot;TripCode&quot;
+ORDER BY &quot;TripCode&quot;, &quot;Depth_m&quot;
 </sql>
         <escapeSql>false</escapeSql>
         <geometry>

--- a/workspaces/imos/JNDI_imos_bgc_db/nrs_depth_binned_ctd_data/layer.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/nrs_depth_binned_ctd_data/layer.xml
@@ -1,0 +1,15 @@
+<layer>
+  <name>nrs_depth_binned_ctd_data</name>
+  <id>LayerInfoImpl-47e1658:17dc02c5512:-7ffb</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-47e1658:17dc02c5512:-7ffc</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>


### PR DESCRIPTION
Please not that `file_id`, `trip_code` and `geom` columns cannot be excluded from the final product.