### PR TITLE
Combined bgc product and sub-products layers

### DIFF
--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_chemistry_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_chemistry_data/featuretype.xml
@@ -1,0 +1,71 @@
+<featureType>
+  <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7ff8</id>
+  <name>bgc_chemistry_data</name>
+  <nativeName>bgc_chemistry_data</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>bgc_chemistry_data</title>
+  <keywords>
+    <string>features</string>
+    <string>bgc_chemistry_data</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>bgc_chemistry_data</name>
+        <sql>SELECT *&#xd;
+FROM imos_bgc_db.bgc_chemistry_data&#xd;
+ORDER BY &quot;Project&quot;, &quot;TripCode&quot;
+</sql>
+        <escapeSql>false</escapeSql>
+        <geometry>
+          <name>geom</name>
+          <type>Point</type>
+          <srid>4326</srid>
+        </geometry>
+      </virtualTable>
+    </entry>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--22c97b22:17b283bfd43:-7fff</id>
+  </store>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_chemistry_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_chemistry_data/featuretype.xml
@@ -42,7 +42,7 @@
         <name>bgc_chemistry_data</name>
         <sql>SELECT *&#xd;
 FROM imos_bgc_db.bgc_chemistry_data&#xd;
-ORDER BY &quot;Project&quot;, &quot;TripCode&quot;
+ORDER BY &quot;Project&quot;, &quot;TripCode&quot;, &quot;Depth_m&quot;
 </sql>
         <escapeSql>false</escapeSql>
         <geometry>

--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_chemistry_data/layer.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_chemistry_data/layer.xml
@@ -1,0 +1,15 @@
+<layer>
+  <name>bgc_chemistry_data</name>
+  <id>LayerInfoImpl--5989a051:17e50309600:-7ff7</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7ff8</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_picoplankton_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_picoplankton_data/featuretype.xml
@@ -42,7 +42,7 @@
         <name>bgc_picoplankton_data</name>
         <sql>SELECT *&#xd;
 FROM imos_bgc_db.bgc_picoplankton_data&#xd;
-ORDER BY &quot;Project&quot;, &quot;TripCode&quot;
+ORDER BY &quot;Project&quot;, &quot;TripCode&quot;, &quot;Depth_m&quot;
 </sql>
         <escapeSql>false</escapeSql>
         <geometry>

--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_picoplankton_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_picoplankton_data/featuretype.xml
@@ -1,0 +1,71 @@
+<featureType>
+  <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7ff3</id>
+  <name>bgc_picoplankton_data</name>
+  <nativeName>bgc_picoplankton_data</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>bgc_picoplankton_data</title>
+  <keywords>
+    <string>features</string>
+    <string>bgc_picoplankton_data</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>bgc_picoplankton_data</name>
+        <sql>SELECT *&#xd;
+FROM imos_bgc_db.bgc_picoplankton_data&#xd;
+ORDER BY &quot;Project&quot;, &quot;TripCode&quot;
+</sql>
+        <escapeSql>false</escapeSql>
+        <geometry>
+          <name>geom</name>
+          <type>Point</type>
+          <srid>4326</srid>
+        </geometry>
+      </virtualTable>
+    </entry>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--22c97b22:17b283bfd43:-7fff</id>
+  </store>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_picoplankton_data/layer.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_picoplankton_data/layer.xml
@@ -1,0 +1,15 @@
+<layer>
+  <name>bgc_picoplankton_data</name>
+  <id>LayerInfoImpl--5989a051:17e50309600:-7ff2</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7ff3</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_pigments_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_pigments_data/featuretype.xml
@@ -42,7 +42,7 @@
         <name>bgc_pigments_data</name>
         <sql>SELECT *&#xd;
 FROM imos_bgc_db.bgc_pigments_data&#xd;
-ORDER BY &quot;Project&quot;, &quot;TripCode&quot;
+ORDER BY &quot;Project&quot;, &quot;TripCode&quot;, &quot;Depth_m&quot;
 </sql>
         <escapeSql>false</escapeSql>
         <geometry>

--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_pigments_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_pigments_data/featuretype.xml
@@ -1,0 +1,71 @@
+<featureType>
+  <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7ff0</id>
+  <name>bgc_pigments_data</name>
+  <nativeName>bgc_pigments_data</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>bgc_pigments_data</title>
+  <keywords>
+    <string>features</string>
+    <string>bgc_pigments_data</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>bgc_pigments_data</name>
+        <sql>SELECT *&#xd;
+FROM imos_bgc_db.bgc_pigments_data&#xd;
+ORDER BY &quot;Project&quot;, &quot;TripCode&quot;
+</sql>
+        <escapeSql>false</escapeSql>
+        <geometry>
+          <name>geom</name>
+          <type>Point</type>
+          <srid>4326</srid>
+        </geometry>
+      </virtualTable>
+    </entry>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--22c97b22:17b283bfd43:-7fff</id>
+  </store>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_pigments_data/layer.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_pigments_data/layer.xml
@@ -1,0 +1,15 @@
+<layer>
+  <name>bgc_pigments_data</name>
+  <id>LayerInfoImpl--5989a051:17e50309600:-7fef</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7ff0</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_tss_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_tss_data/featuretype.xml
@@ -42,7 +42,8 @@
         <name>bgc_tss_data</name>
         <sql>SELECT *&#xd;
 FROM imos_bgc_db.bgc_tss_data&#xd;
-ORDER BY &quot;Project&quot;, &quot;TripCode&quot;
+ORDER BY &quot;Project&quot;, &quot;TripCode&quot;, &quot;Depth_m&quot;
+
 </sql>
         <escapeSql>false</escapeSql>
         <geometry>

--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_tss_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_tss_data/featuretype.xml
@@ -1,0 +1,71 @@
+<featureType>
+  <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7fe9</id>
+  <name>bgc_tss_data</name>
+  <nativeName>bgc_tss_data</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>bgc_tss_data</title>
+  <keywords>
+    <string>features</string>
+    <string>bgc_tss_data</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>bgc_tss_data</name>
+        <sql>SELECT *&#xd;
+FROM imos_bgc_db.bgc_tss_data&#xd;
+ORDER BY &quot;Project&quot;, &quot;TripCode&quot;
+</sql>
+        <escapeSql>false</escapeSql>
+        <geometry>
+          <name>geom</name>
+          <type>Point</type>
+          <srid>4326</srid>
+        </geometry>
+      </virtualTable>
+    </entry>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--22c97b22:17b283bfd43:-7fff</id>
+  </store>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_imos_bgc_db/bgc_tss_data/layer.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/bgc_tss_data/layer.xml
@@ -1,0 +1,15 @@
+<layer>
+  <name>bgc_tss_data</name>
+  <id>LayerInfoImpl--5989a051:17e50309600:-7fe8</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7fe9</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_data/featuretype.xml
@@ -42,7 +42,7 @@
         <name>combined_bgc_data</name>
         <sql>SELECT *&#xd;
 FROM imos_bgc_db.combined_bgc_data&#xd;
-ORDER BY &quot;Project&quot;, &quot;TripCode&quot;
+ORDER BY &quot;Project&quot;, &quot;TripCode&quot;, &quot;Depth_m&quot;
 </sql>
         <escapeSql>false</escapeSql>
         <geometry>

--- a/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_data/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_data/featuretype.xml
@@ -1,0 +1,71 @@
+<featureType>
+  <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7fe5</id>
+  <name>combined_bgc_data</name>
+  <nativeName>combined_bgc_data</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>combined_bgc_data</title>
+  <keywords>
+    <string>features</string>
+    <string>combined_bgc_data</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="JDBC_VIRTUAL_TABLE">
+      <virtualTable>
+        <name>combined_bgc_data</name>
+        <sql>SELECT *&#xd;
+FROM imos_bgc_db.combined_bgc_data&#xd;
+ORDER BY &quot;Project&quot;, &quot;TripCode&quot;
+</sql>
+        <escapeSql>false</escapeSql>
+        <geometry>
+          <name>geom</name>
+          <type>Point</type>
+          <srid>4326</srid>
+        </geometry>
+      </virtualTable>
+    </entry>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--22c97b22:17b283bfd43:-7fff</id>
+  </store>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_data/filters.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_data/filters.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<filters>
+    <filter>
+        <name>Project</name>
+        <type>string</type>
+        <label>Project</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>StationName</name>
+        <type>string</type>
+        <label>Station</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>SampleDate_Local</name>
+        <type>datetime</type>
+        <label>Sample Date local</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>geom</name>
+        <type>geometrypropertytype</type>
+        <label>Geom</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+</filters>

--- a/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_data/layer.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_data/layer.xml
@@ -1,0 +1,15 @@
+<layer>
+  <name>combined_bgc_data</name>
+  <id>LayerInfoImpl--5989a051:17e50309600:-7fe4</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7fe5</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_map/featuretype.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_map/featuretype.xml
@@ -1,0 +1,63 @@
+<featureType>
+  <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7ffc</id>
+  <name>combined_bgc_map</name>
+  <nativeName>combined_bgc_map</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>combined_bgc_map</title>
+  <keywords>
+    <string>features</string>
+    <string>combined_bgc_map</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="elevation">
+      <dimensionInfo>
+        <enabled>false</enabled>
+      </dimensionInfo>
+    </entry>
+    <entry key="time">
+      <dimensionInfo>
+        <enabled>false</enabled>
+      </dimensionInfo>
+    </entry>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--22c97b22:17b283bfd43:-7fff</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_map/layer.xml
+++ b/workspaces/imos/JNDI_imos_bgc_db/combined_bgc_map/layer.xml
@@ -1,0 +1,15 @@
+<layer>
+  <name>combined_bgc_map</name>
+  <id>LayerInfoImpl--5989a051:17e50309600:-7ffb</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl--5989a051:17e50309600:-7ffc</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>


### PR DESCRIPTION
This is good to be reviewed as works fine in my stack. Filters are only on the `combined_bgc_data` product, as the subproducts can be selected in step 3 only. Not sure we agreed earlier in any specific point style for `combined_bgc_map`