### PR TITLE
Revert "(BugFix) Remove SRS OC LJCO WWS store causing issues with poorly performing views/tables"

### DIFF
--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/datastore.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/datastore.xml
@@ -1,0 +1,24 @@
+<dataStore>
+  <id>DataStoreInfoImpl--a5e2e8a:151c1e676ed:-7ffc</id>
+  <name>JNDI_srs_oc_ljco_wws</name>
+  <description>Lucinda Jetty Weather Water Sampling</description>
+  <type>PostGIS (JNDI)</type>
+  <enabled>true</enabled>
+  <workspace>
+    <id>WorkspaceInfoImpl-5f0a648d:1428d0d11a9:-8000</id>
+  </workspace>
+  <connectionParameters>
+    <entry key="schema">srs_oc_ljco_wws</entry>
+    <entry key="dbtype">postgis</entry>
+    <entry key="Loose bbox">true</entry>
+    <entry key="Expose primary keys">false</entry>
+    <entry key="encode functions">false</entry>
+    <entry key="fetch size">1000</entry>
+    <entry key="preparedStatements">false</entry>
+    <entry key="jndiReferenceName">java:comp/env/jdbc/harvest_read</entry>
+    <entry key="Estimated extends">true</entry>
+    <entry key="Support on the fly geometry simplification">true</entry>
+    <entry key="namespace">imos.mod</entry>
+  </connectionParameters>
+  <__default>false</__default>
+</dataStore>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_all_products_timeseries_map/content.ftl
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_all_products_timeseries_map/content.ftl
@@ -1,0 +1,21 @@
+<#if (features?size = 100) >
+<h3>Total number of data files at this site: > 100</h3> 
+<#else>
+<h3>Total number of data files at this site: ${features?size}</h3> 
+</#if>
+<BR>
+<div class="feature">
+<#list features as feature>
+
+<#if (feature_index < 5) >
+<div class="featurewhite">
+<b>Instrument:</b> ${feature.instrument.value}<br/>
+<b>Time Period:</b> ${feature.period.value}<br/>
+<b>Product Version:</b> ${feature.product.value}<br/>
+<b>Instrument:</b> ${feature.instrument.value}<br/>
+<b>Time coverage start and end:</b> ${feature.time_coverage_start.value} - ${feature.time_coverage_end.value}<br/>
+<BR>
+</div>
+</#if>
+</#list>
+</div>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_all_products_timeseries_map/featuretype.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_all_products_timeseries_map/featuretype.xml
@@ -1,0 +1,55 @@
+<featureType>
+  <id>FeatureTypeInfoImpl--58d17e5d:18164c84cd6:-7fff</id>
+  <name>srs_oc_ljco_wws_all_products_timeseries_map</name>
+  <nativeName>srs_oc_ljco_wws_all_products_timeseries_map</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_ljco_wws_all_products_timeseries_map</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_ljco_wws_all_products_timeseries_map</string>
+  </keywords>
+  <metadataLinks>
+    <metadataLink>
+      <type>text/xml</type>
+      <metadataType>TC211</metadataType>
+      <content>https://catalogue-123.aodn.org.au/geonetwork/srv/eng/xml_iso19139.mcp?uuid=4ac6bf81-cd37-4611-8da8-4d5ae5e2bda3&amp;styleSheet=xml_iso19139.mcp.xsl</content>
+    </metadataLink>
+  </metadataLinks>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--a5e2e8a:151c1e676ed:-7ffc</id>
+  </store>
+  <serviceConfiguration>false</serviceConfiguration>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_all_products_timeseries_map/filters.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_all_products_timeseries_map/filters.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<filters>
+    <filter>
+        <name>instrument</name>
+        <type>string</type>
+        <label>Instrument</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>period</name>
+        <type>string</type>
+        <label>Time Period</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>product</name>
+        <type>string</type>
+        <label>Product Version</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>geom</name>
+        <type>geometrypropertytype</type>
+        <label>Bounding Box</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+    </filter>
+    <filter>
+        <name>time</name>
+        <type>datetime</type>
+        <label>Time</label>
+        <visualised>true</visualised>
+        <excludedFromDownload>false</excludedFromDownload>
+        <wmsStartDateName>time_coverage_start</wmsStartDateName>
+        <wmsEndDateName>time_coverage_end</wmsEndDateName>
+  </filter>
+</filters>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_all_products_timeseries_map/layer.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_all_products_timeseries_map/layer.xml
@@ -1,0 +1,15 @@
+<layer>
+  <name>srs_oc_ljco_wws_all_products_timeseries_map</name>
+  <id>LayerInfoImpl--58d17e5d:18164c84cd6:-7ffe</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--1ed5fa67:15c51604392:-75b3</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl--58d17e5d:18164c84cd6:-7fff</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_daily_ecotriplet_fv01_timeseries_data/featuretype.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_daily_ecotriplet_fv01_timeseries_data/featuretype.xml
@@ -1,0 +1,56 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-71a6a394:181f558af16:-7db6</id>
+  <name>srs_oc_ljco_wws_daily_ecotriplet_fv01_timeseries_data</name>
+  <nativeName>srs_oc_ljco_wws_daily_ecotriplet_fv01_timeseries_data</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_ljco_wws_daily_ecotriplet_fv01_timeseries_data</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_ljco_wws_daily_ecotriplet_fv01_timeseries_data</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>146.38616</minx>
+    <maxx>146.38636</maxx>
+    <miny>-18.51967</miny>
+    <maxy>-18.519470000000002</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>146.38616</minx>
+    <maxx>146.38636</maxx>
+    <miny>-18.51967</miny>
+    <maxy>-18.519470000000002</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--a5e2e8a:151c1e676ed:-7ffc</id>
+  </store>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_daily_ecotriplet_fv01_timeseries_data/layer.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_daily_ecotriplet_fv01_timeseries_data/layer.xml
@@ -1,0 +1,15 @@
+<layer>
+  <name>srs_oc_ljco_wws_daily_ecotriplet_fv01_timeseries_data</name>
+  <id>LayerInfoImpl-71a6a394:181f558af16:-7db5</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-71a6a394:181f558af16:-7db6</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_daily_wqm_fv01_timeseries_data/featuretype.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_daily_wqm_fv01_timeseries_data/featuretype.xml
@@ -1,0 +1,53 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-71a6a394:181f558af16:-7dc0</id>
+  <name>srs_oc_ljco_wws_daily_wqm_fv01_timeseries_data</name>
+  <nativeName>srs_oc_ljco_wws_daily_wqm_fv01_timeseries_data</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_ljco_wws_daily_wqm_fv01_timeseries_data</title>
+  <keywords>
+    <string>srs_oc_ljco_wws_daily_wqm_fv01_timeseries_data</string>
+    <string>features</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>146.38616</minx>
+    <maxx>146.38636</maxx>
+    <miny>-18.51967</miny>
+    <maxy>-18.519470000000002</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>146.38616</minx>
+    <maxx>146.38636</maxx>
+    <miny>-18.51967</miny>
+    <maxy>-18.519470000000002</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--a5e2e8a:151c1e676ed:-7ffc</id>
+  </store>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_daily_wqm_fv01_timeseries_data/layer.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_daily_wqm_fv01_timeseries_data/layer.xml
@@ -1,0 +1,16 @@
+<layer>
+  <name>srs_oc_ljco_wws_daily_wqm_fv01_timeseries_data</name>
+  <id>LayerInfoImpl-71a6a394:181f558af16:-7dbf</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-71a6a394:181f558af16:-7dc0</id>
+  </resource>
+  <queryable>false</queryable>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_hourly_ecotriplet_fv01_timeseries_data/featuretype.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_hourly_ecotriplet_fv01_timeseries_data/featuretype.xml
@@ -1,0 +1,56 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-71a6a394:181f558af16:-7dbc</id>
+  <name>srs_oc_ljco_wws_hourly_ecotriplet_fv01_timeseries_data</name>
+  <nativeName>srs_oc_ljco_wws_hourly_ecotriplet_fv01_timeseries_data</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_ljco_wws_hourly_ecotriplet_fv01_timeseries_data</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_ljco_wws_hourly_ecotriplet_fv01_timeseries_data</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>146.38616</minx>
+    <maxx>146.38636</maxx>
+    <miny>-18.51967</miny>
+    <maxy>-18.519470000000002</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>146.38616</minx>
+    <maxx>146.38636</maxx>
+    <miny>-18.51967</miny>
+    <maxy>-18.519470000000002</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--a5e2e8a:151c1e676ed:-7ffc</id>
+  </store>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_hourly_ecotriplet_fv01_timeseries_data/layer.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_hourly_ecotriplet_fv01_timeseries_data/layer.xml
@@ -1,0 +1,16 @@
+<layer>
+  <name>srs_oc_ljco_wws_hourly_ecotriplet_fv01_timeseries_data</name>
+  <id>LayerInfoImpl-71a6a394:181f558af16:-7dbb</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-71a6a394:181f558af16:-7dbc</id>
+  </resource>
+  <queryable>false</queryable>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_hourly_wqm_fv01_timeseries_data/featuretype.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_hourly_wqm_fv01_timeseries_data/featuretype.xml
@@ -1,0 +1,56 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-71a6a394:181f558af16:-7dbe</id>
+  <name>srs_oc_ljco_wws_hourly_wqm_fv01_timeseries_data</name>
+  <nativeName>srs_oc_ljco_wws_hourly_wqm_fv01_timeseries_data</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>srs_oc_ljco_wws_hourly_wqm_fv01_timeseries_data</title>
+  <keywords>
+    <string>features</string>
+    <string>srs_oc_ljco_wws_hourly_wqm_fv01_timeseries_data</string>
+  </keywords>
+  <nativeCRS>GEOGCS[&quot;WGS 84&quot;, 
+  DATUM[&quot;World Geodetic System 1984&quot;, 
+    SPHEROID[&quot;WGS 84&quot;, 6378137.0, 298.257223563, AUTHORITY[&quot;EPSG&quot;,&quot;7030&quot;]], 
+    AUTHORITY[&quot;EPSG&quot;,&quot;6326&quot;]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0, AUTHORITY[&quot;EPSG&quot;,&quot;8901&quot;]], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH], 
+  AUTHORITY[&quot;EPSG&quot;,&quot;4326&quot;]]</nativeCRS>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>146.38616</minx>
+    <maxx>146.38636</maxx>
+    <miny>-18.51967</miny>
+    <maxy>-18.519470000000002</maxy>
+    <crs>EPSG:4326</crs>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>146.38616</minx>
+    <maxx>146.38636</maxx>
+    <miny>-18.51967</miny>
+    <maxy>-18.519470000000002</maxy>
+    <crs>EPSG:4326</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl--a5e2e8a:151c1e676ed:-7ffc</id>
+  </store>
+  <serviceConfiguration>true</serviceConfiguration>
+  <disabledServices>
+    <string>WMS</string>
+  </disabledServices>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+  <padWithZeros>false</padWithZeros>
+  <forcedDecimal>false</forcedDecimal>
+  <overridingServiceSRS>false</overridingServiceSRS>
+  <skipNumberMatched>false</skipNumberMatched>
+  <circularArcPresent>false</circularArcPresent>
+</featureType>

--- a/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_hourly_wqm_fv01_timeseries_data/layer.xml
+++ b/workspaces/imos/JNDI_srs_oc_ljco_wws/srs_oc_ljco_wws_hourly_wqm_fv01_timeseries_data/layer.xml
@@ -1,0 +1,16 @@
+<layer>
+  <name>srs_oc_ljco_wws_hourly_wqm_fv01_timeseries_data</name>
+  <id>LayerInfoImpl-71a6a394:181f558af16:-7dbd</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--3a52b6b4:1428ce0125d:-8000</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-71a6a394:181f558af16:-7dbe</id>
+  </resource>
+  <queryable>false</queryable>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>


### PR DESCRIPTION
Reverts aodn/geoserver-config#749

The views are now performing fine on both RC and prod since the new changes added to the harvester
https://github.com/aodn/harvesters/pull/979