### PR TITLE
Restore `aad_so_cpr_map` layer

### DIFF
--- a/workspaces/imos/JNDI_legacy_cpr/aad_so_cpr_map/content.ftl
+++ b/workspaces/imos/JNDI_legacy_cpr/aad_so_cpr_map/content.ftl
@@ -1,0 +1,48 @@
+<#import "config.ftl" as my>
+
+<h2>Southern Ocean (SO-CPR Survey)</h2>
+<div class="feature">
+<#list features as feature>
+
+    <!--  Header info - only listed once. -->
+    <#if (feature_index < 1) >
+    
+        <h3>Ship code: ${feature.ship_code.value}</h3>
+        <h4>${feature.date_time.value}</h4>
+        <p>
+	        Tow number: <b>${feature.tow_number.value}</b>
+	        <br>Segment number: <b>${feature.segment_no.value}</b>
+	        <br>Segment length (nautical miles): <b>${feature.segment_length.value}</b>
+	        <br>Lat: <b>${feature.lat.value}</b> Lon: <b>${feature.lon.value}</b>
+	        <#if (feature.flu_value.value != "") >
+                <br>Fluorometry value: <b>${feature.flu_value.value}</b>
+	        </#if>
+            <#if (feature.tsg_sal.value != "") > 
+                <br>Salinity: <b>${feature.tsg_sal.value}</b>
+            </#if>
+            <#if (feature.w_temp_hi.value != "") >
+                <br>Temperature: <b>${feature.w_temp_hi.value}</b>
+            </#if>
+            <#if (feature.licor_r.value != "") >
+                <br>Light as PAR: <b>${feature.licor_r.value}</b>
+            </#if>
+	        <br>Total Abundance: <b>${feature.total_abundance.value}</b>
+        </p>
+        
+        <p>
+            Please contact <a href="mailto:graham.hosie@aad.gov.au">Graham Hosie</a> for help with using the data.
+                
+                
+        </p>
+    </#if>
+    
+</#list>
+
+<h3>Species Abundance Counts</h3>
+     <#list features as feature>
+    
+        ${feature.species_name.value}:
+        <b>${feature.count.value}</b><br/>
+    
+    </#list>
+</div>

--- a/workspaces/imos/JNDI_legacy_cpr/aad_so_cpr_map/featuretype.xml
+++ b/workspaces/imos/JNDI_legacy_cpr/aad_so_cpr_map/featuretype.xml
@@ -1,0 +1,51 @@
+<featureType>
+  <id>FeatureTypeInfoImpl-2a063d6c:14858ec12b2:5508</id>
+  <name>aad_so_cpr_map</name>
+  <nativeName>so_cpr_geoserver_view</nativeName>
+  <namespace>
+    <id>NamespaceInfoImpl-5f0a648d:1428d0d11a9:-7fff</id>
+  </namespace>
+  <title>Southern Ocean CPR Zooplankton</title>
+  <abstract>Southern Ocean CPR Zooplankton Abundance Survey</abstract>
+  <keywords>
+    <string>so_cpr_geoserver_view</string>
+    <string>features</string>
+  </keywords>
+  <metadataLinks>
+    <metadataLink>
+      <type>text/xml</type>
+      <metadataType>TC211</metadataType>
+      <content>https://catalogue-123.aodn.org.au/geonetwork/srv/eng/xml_iso19139.mcp?uuid=d431c584-8d1e-429b-ad6d-0e03be3b95b2&amp;styleSheet=xml_iso19139.mcp.xsl</content>
+    </metadataLink>
+  </metadataLinks>
+  <srs>EPSG:4326</srs>
+  <nativeBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+  </nativeBoundingBox>
+  <latLonBoundingBox>
+    <minx>-180.0</minx>
+    <maxx>180.0</maxx>
+    <miny>-90.0</miny>
+    <maxy>90.0</maxy>
+    <crs>GEOGCS[&quot;WGS84(DD)&quot;, 
+  DATUM[&quot;WGS84&quot;, 
+    SPHEROID[&quot;WGS84&quot;, 6378137.0, 298.257223563]], 
+  PRIMEM[&quot;Greenwich&quot;, 0.0], 
+  UNIT[&quot;degree&quot;, 0.017453292519943295], 
+  AXIS[&quot;Geodetic longitude&quot;, EAST], 
+  AXIS[&quot;Geodetic latitude&quot;, NORTH]]</crs>
+  </latLonBoundingBox>
+  <projectionPolicy>FORCE_DECLARED</projectionPolicy>
+  <enabled>true</enabled>
+  <metadata>
+    <entry key="cachingEnabled">false</entry>
+  </metadata>
+  <store class="dataStore">
+    <id>DataStoreInfoImpl-3ab8edf6:12f766e0eb9:-8000</id>
+  </store>
+  <maxFeatures>0</maxFeatures>
+  <numDecimals>0</numDecimals>
+</featureType>

--- a/workspaces/imos/JNDI_legacy_cpr/aad_so_cpr_map/filters.xml
+++ b/workspaces/imos/JNDI_legacy_cpr/aad_so_cpr_map/filters.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<filters>
+  <filter>
+    <name>position</name>
+    <type>geometrypropertytype</type>
+    <label>geom</label>
+    <visualised>true</visualised>
+    <excludedFromDownload>false</excludedFromDownload>
+  </filter>
+  <filter>
+    <name>species_name</name>
+    <type>string</type>
+    <label>Species Name</label>
+    <visualised>true</visualised>
+    <excludedFromDownload>false</excludedFromDownload>
+  </filter>
+  <filter>
+    <name>date_time</name>
+    <type>datetime</type>
+    <label>Time</label>
+    <visualised>true</visualised>
+    <excludedFromDownload>false</excludedFromDownload>
+  </filter>
+  <filter>
+    <name>ship_code</name>
+    <type>string</type>
+    <label>Vessel Code</label>
+    <visualised>true</visualised>
+    <excludedFromDownload>false</excludedFromDownload>
+  </filter>
+</filters>

--- a/workspaces/imos/JNDI_legacy_cpr/aad_so_cpr_map/layer.xml
+++ b/workspaces/imos/JNDI_legacy_cpr/aad_so_cpr_map/layer.xml
@@ -1,0 +1,15 @@
+<layer>
+  <name>aad_so_cpr_map</name>
+  <id>LayerInfoImpl-2a063d6c:14858ec12b2:5509</id>
+  <type>VECTOR</type>
+  <defaultStyle>
+    <id>StyleInfoImpl--76dc30d3:13ba6555f5c:-44c8</id>
+  </defaultStyle>
+  <resource class="featureType">
+    <id>FeatureTypeInfoImpl-2a063d6c:14858ec12b2:5508</id>
+  </resource>
+  <attribution>
+    <logoWidth>0</logoWidth>
+    <logoHeight>0</logoHeight>
+  </attribution>
+</layer>

--- a/workspaces/imos/JNDI_legacy_cpr/datastore.xml
+++ b/workspaces/imos/JNDI_legacy_cpr/datastore.xml
@@ -1,0 +1,22 @@
+<dataStore>
+  <id>DataStoreInfoImpl-3ab8edf6:12f766e0eb9:-8000</id>
+  <name>JNDI_legacy_cpr</name>
+  <description>Continuous Plankton Recorder JDBC</description>
+  <type>PostGIS (JNDI)</type>
+  <enabled>true</enabled>
+  <workspace>
+    <id>WorkspaceInfoImpl-5f0a648d:1428d0d11a9:-8000</id>
+  </workspace>
+  <connectionParameters>
+    <entry key='schema'>legacy_cpr</entry>
+    <entry key='dbtype'>postgis</entry>
+    <entry key='Loose bbox'>true</entry>
+    <entry key='Expose primary keys'>false</entry>
+    <entry key="fetch size">1000</entry>
+    <entry key='Max open prepared statements'>50</entry>
+    <entry key='preparedStatements'>false</entry>
+    <entry key='jndiReferenceName'>java:comp/env/jdbc/harvest_read</entry>
+    <entry key='namespace'>imos.mod</entry>
+  </connectionParameters>
+  <__default>false</__default>
+</dataStore>


### PR DESCRIPTION
Turns out we still need this layer for a static collection harvested from the AAD (see [here](https://github.com/aodn/PO-Backlog/issues/3123#issuecomment-1350117359) for more)

This _partially_ reverts #750.

Note that I have also renamed the workspace directory from `JNDI_cpr` to `JNDI_legacy_cpr` to match the db schema name (following convention).