### PR TITLE
world_depth_data: encode percent for lat and long params

### DIFF
--- a/workspaces/depth/legacy_bathy/world_depth_data/featuretype.xml
+++ b/workspaces/depth/legacy_bathy/world_depth_data/featuretype.xml
@@ -38,8 +38,8 @@
     world_depth.depth,&#xd;
     world_depth.geom&#xd;
    FROM legacy_bathy.world_depth&#xd;
-  WHERE st_dwithin(world_depth.geom, st_geomfromtext(&apos;POINT(&#x25;lon&#x25; &#x25;lat&#x25;)&apos;::text, 4326), 0.12::double precision)&#xd;
-  ORDER BY (st_distance(world_depth.geom, st_geomfromtext(&apos;POINT(&#x25;lon&#x25; &#x25;lat&#x25;)&apos;::text, 4326)))&#xd;
+  WHERE st_dwithin(world_depth.geom, st_geomfromtext(&apos;POINT(%lon% %lat%)&apos;::text, 4326), 0.12::double precision)&#xd;
+  ORDER BY (st_distance(world_depth.geom, st_geomfromtext(&apos;POINT(%lon% %lat%)&apos;::text, 4326)))&#xd;
  LIMIT 1
 </sql>
         <escapeSql>false</escapeSql>
@@ -51,10 +51,12 @@
         <parameter>
           <name>lon</name>
           <regexpValidator>^[-+]?[0-9]*\.?[0-9]+$</regexpValidator>
+          <defaultValue>0</defaultValue>
         </parameter>
         <parameter>
           <name>lat</name>
           <regexpValidator>^[-+]?[0-9]*\.?[0-9]+$</regexpValidator>
+          <defaultValue>0</defaultValue>
         </parameter>
       </virtualTable>
     </entry>

--- a/workspaces/depth/legacy_bathy/world_depth_data/featuretype.xml
+++ b/workspaces/depth/legacy_bathy/world_depth_data/featuretype.xml
@@ -38,8 +38,8 @@
     world_depth.depth,&#xd;
     world_depth.geom&#xd;
    FROM legacy_bathy.world_depth&#xd;
-  WHERE st_dwithin(world_depth.geom, st_geomfromtext(&apos;POINT(%lon% %lat%)&apos;::text, 4326), 0.12::double precision)&#xd;
-  ORDER BY (st_distance(world_depth.geom, st_geomfromtext(&apos;POINT(%lon% %lat%)&apos;::text, 4326)))&#xd;
+  WHERE st_dwithin(world_depth.geom, st_geomfromtext(&apos;POINT(&percnt;lon&percnt; &percnt;lat&percnt;)&apos;::text, 4326), 0.12::double precision)&#xd;
+  ORDER BY (st_distance(world_depth.geom, st_geomfromtext(&apos;POINT(&percnt;lon&percnt; &percnt;lat&percnt;)&apos;::text, 4326)))&#xd;
  LIMIT 1
 </sql>
         <escapeSql>false</escapeSql>

--- a/workspaces/depth/legacy_bathy/world_depth_data/featuretype.xml
+++ b/workspaces/depth/legacy_bathy/world_depth_data/featuretype.xml
@@ -38,8 +38,8 @@
     world_depth.depth,&#xd;
     world_depth.geom&#xd;
    FROM legacy_bathy.world_depth&#xd;
-  WHERE st_dwithin(world_depth.geom, st_geomfromtext(&apos;POINT(&percnt;lon&percnt; &percnt;lat&percnt;)&apos;::text, 4326), 0.12::double precision)&#xd;
-  ORDER BY (st_distance(world_depth.geom, st_geomfromtext(&apos;POINT(&percnt;lon&percnt; &percnt;lat&percnt;)&apos;::text, 4326)))&#xd;
+  WHERE st_dwithin(world_depth.geom, st_geomfromtext(&apos;POINT(&#x25;lon&#x25; &#x25;lat&#x25;)&apos;::text, 4326), 0.12::double precision)&#xd;
+  ORDER BY (st_distance(world_depth.geom, st_geomfromtext(&apos;POINT(&#x25;lon&#x25; &#x25;lat&#x25;)&apos;::text, 4326)))&#xd;
  LIMIT 1
 </sql>
         <escapeSql>false</escapeSql>


### PR DESCRIPTION
This is an attempt to solve this issue: https://github.com/aodn/issues/issues/1330.

All of the other special characters in the query are escaped except the percent symbols around the SQL parameters. According to the logs these parameters are not being substituted.

This PR attempts a fix by replacing `%` with `&#x25;`.